### PR TITLE
Updated the LessonList to show what type of lesson each one is

### DIFF
--- a/src/Routes/LessonList.js
+++ b/src/Routes/LessonList.js
@@ -11,6 +11,16 @@ const LessonList = () => {
   const { auth } = useAuth();
   const { showSnackbar } = useSnackbar();
   const theme = useTheme();
+  const categoryColors = {
+    flashcards: "primary",
+    practice: "secondary",
+    grammar: "warning",
+  };
+  const categoryRoutes = {
+    flashcards: "/flashcards",
+    practice: "/practice",
+    grammar: "/grammar",
+  };
 
   const {
     data: lessons,
@@ -89,11 +99,11 @@ const LessonList = () => {
           <Typography variant="h6">{lesson.title}</Typography>
           <Button
             variant="contained"
-            color="primary"
+            color={categoryColors[lesson.category]}
             component={Link}
-            to={`/flashcards/${lesson._id}`}
+            to={`${categoryRoutes[lesson.category]}/${lesson._id}`}
           >
-            Flashcards
+            {lesson.category}
           </Button>
         </Box>
       ))}


### PR DESCRIPTION
### Brief Description
<!-- Describe the purpose of this pull request -->
In this pull request, I updated the lesson list page to use different button text and colors to show what type of lesson each one is.
### Changes
<!-- Describe the changes made in this pull request -->
- The lesson list now checks each lesson's category, and changes what color the button next to it is
- It also changes which route the button goes to, with each category having an associated route ("/flashcards", "/practice", "/grammar")