### PR TITLE
Implement practice pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-router": "^6.26.0",
         "react-router-dom": "^6.26.0",
         "react-scripts": "5.0.1",
+        "react-transition-group": "^4.4.5",
         "wanakana": "^5.3.1",
         "web-vitals": "^4.2.3"
       },
@@ -14505,6 +14506,7 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-router": "^6.26.0",
     "react-router-dom": "^6.26.0",
     "react-scripts": "5.0.1",
+    "react-transition-group": "^4.4.5",
     "wanakana": "^5.3.1",
     "web-vitals": "^4.2.3"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -28,6 +28,7 @@ import FlashcardLesson from "./Routes/FlashcardLesson";
 import LessonList from "./Routes/LessonList";
 import { AuthProvider } from "./Contexts/AuthContext";
 import GrammarLesson from "./Routes/GrammarLesson";
+import PracticeLesson from "./Routes/PracticeLesson";
 
 const purpleBase = "#8c00cc";
 const greenBase = "#18b201";
@@ -134,6 +135,7 @@ function App() {
       { path: "/lessons", element: <LessonList /> },
       { path: "/flashcards/:lessonId", element: <FlashcardLesson /> },
       { path: "/grammar/:lessonId", element: <GrammarLesson /> },
+      { path: "/practice/:lessonId", element: <PracticeLesson /> },
     ]);
 
   return (

--- a/src/Components/TranslationQuestion.jsx
+++ b/src/Components/TranslationQuestion.jsx
@@ -10,11 +10,27 @@ const TranslationQuestion = ({ sentence, onNext }) => {
   const theme = useTheme();
   const inputRef = useRef(null);
 
+  // Reset state on each sentence
   useEffect(() => {
     setUserAnswer("");
     setIsCorrect(null);
     inputRef.current.focus();
   }, [sentence]);
+
+  // Listener for the enter key if the input is focused
+  useEffect(() => {
+    const handleKeyPress = (event) => {
+      if (event.code === "Enter") {
+        event.preventDefault();
+        checkAnswer();
+      }
+    };
+
+    inputRef.current.addEventListener("keydown", handleKeyPress);
+    return () => {
+      inputRef.current.removeEventListener("keydown", handleKeyPress);
+    };
+  });
 
   const cleanString = (inputString) => {
     return inputString

--- a/src/Components/TranslationQuestion.jsx
+++ b/src/Components/TranslationQuestion.jsx
@@ -14,12 +14,19 @@ const TranslationQuestion = ({ sentence, onNext }) => {
     setIsCorrect(null);
   }, [sentence]);
 
+  const cleanString = (inputString) => {
+    return inputString
+      .trim()
+      .toLowerCase()
+      .replaceAll(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, "");
+  };
   const possibleAnswers = sentence.possible_answers.map((answer) =>
-    answer.trim().toLowerCase(),
+    // remove all punctuation and make lowercase
+    cleanString(answer),
   );
 
   const checkAnswer = () => {
-    if (possibleAnswers.includes(userAnswer.trim().toLowerCase())) {
+    if (possibleAnswers.includes(cleanString(userAnswer))) {
       setIsCorrect(true);
       showSnackbar("Correct!", "success");
       setTimeout(onNext, 500);

--- a/src/Components/TranslationQuestion.jsx
+++ b/src/Components/TranslationQuestion.jsx
@@ -1,11 +1,18 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Box, TextField, Button, Typography } from "@mui/material";
 import { useSnackbar } from "../Contexts/SnackbarContext";
+import { useTheme } from "@mui/material/styles";
 
 const TranslationQuestion = ({ sentence, onNext }) => {
   const [userAnswer, setUserAnswer] = useState("");
   const [isCorrect, setIsCorrect] = useState();
   const { showSnackbar } = useSnackbar();
+  const theme = useTheme();
+
+  useEffect(() => {
+    setUserAnswer("");
+    setIsCorrect(null);
+  }, [sentence]);
 
   const possibleAnswers = sentence.possible_answers.map((answer) =>
     answer.trim().toLowerCase(),
@@ -15,7 +22,7 @@ const TranslationQuestion = ({ sentence, onNext }) => {
     if (possibleAnswers.includes(userAnswer.trim().toLowerCase())) {
       setIsCorrect(true);
       showSnackbar("Correct!", "success");
-      setTimeout(onNext, 1000);
+      setTimeout(onNext, 500);
     } else {
       setIsCorrect(false);
       showSnackbar("Incorrect", "error");
@@ -28,8 +35,8 @@ const TranslationQuestion = ({ sentence, onNext }) => {
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
-        m: 2,
-        p: 2,
+        m: 8,
+        p: 4,
         border: 1,
         borderColor:
           isCorrect != null && isCorrect
@@ -38,9 +45,15 @@ const TranslationQuestion = ({ sentence, onNext }) => {
               ? "error.main"
               : "primary.main",
         borderRadius: 2,
+        backgroundColor:
+          theme.palette.mode === "dark"
+            ? theme.palette.grey[900]
+            : theme.palette.grey[100],
       }}
     >
-      <Typography variant="h6">{sentence.full_sentence}</Typography>
+      <Typography variant="h6">
+        Please translate this sentence: {sentence.full_sentence}
+      </Typography>
       <TextField
         label="Translate to English"
         value={userAnswer}

--- a/src/Components/TranslationQuestion.jsx
+++ b/src/Components/TranslationQuestion.jsx
@@ -32,17 +32,20 @@ const TranslationQuestion = ({ sentence, onNext }) => {
     };
   });
 
+  // Helper function to remove punctuation and extra spaces, and make it lowercase
   const cleanString = (inputString) => {
     return inputString
       .trim()
       .toLowerCase()
       .replaceAll(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, "");
   };
+
   const possibleAnswers = sentence.possible_answers.map((answer) =>
     // remove all punctuation and make lowercase
     cleanString(answer),
   );
 
+  // Check if the user's answer is correct by comparing it to all answers in the sentence's possible_answers array
   const checkAnswer = () => {
     if (possibleAnswers.includes(cleanString(userAnswer))) {
       setIsCorrect(true);

--- a/src/Components/TranslationQuestion.jsx
+++ b/src/Components/TranslationQuestion.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { Box, TextField, Button, Typography } from "@mui/material";
 import { useSnackbar } from "../Contexts/SnackbarContext";
 import { useTheme } from "@mui/material/styles";
@@ -8,10 +8,12 @@ const TranslationQuestion = ({ sentence, onNext }) => {
   const [isCorrect, setIsCorrect] = useState();
   const { showSnackbar } = useSnackbar();
   const theme = useTheme();
+  const inputRef = useRef(null);
 
   useEffect(() => {
     setUserAnswer("");
     setIsCorrect(null);
+    inputRef.current.focus();
   }, [sentence]);
 
   const cleanString = (inputString) => {
@@ -70,6 +72,7 @@ const TranslationQuestion = ({ sentence, onNext }) => {
         value={userAnswer}
         onChange={(e) => setUserAnswer(e.target.value)}
         sx={{ mt: 2, width: "100%" }}
+        inputRef={inputRef}
       />
       <Button onClick={checkAnswer} variant="contained" sx={{ mt: 2 }}>
         Submit

--- a/src/Components/TranslationQuestion.jsx
+++ b/src/Components/TranslationQuestion.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState, useRef } from "react";
-import { Box, TextField, Button, Typography } from "@mui/material";
+import React, { useEffect, useRef, useState } from "react";
+import { Box, Button, TextField, Typography } from "@mui/material";
 import { useSnackbar } from "../Contexts/SnackbarContext";
 import { useTheme } from "@mui/material/styles";
 

--- a/src/Components/TranslationQuestion.jsx
+++ b/src/Components/TranslationQuestion.jsx
@@ -56,6 +56,10 @@ const TranslationQuestion = ({ sentence, onNext }) => {
           theme.palette.mode === "dark"
             ? theme.palette.grey[900]
             : theme.palette.grey[100],
+        transition: "transform 0.3s ease",
+        "&:hover": {
+          transform: "scale(1.1)",
+        },
       }}
     >
       <Typography variant="h6">

--- a/src/Components/TranslationQuestion.jsx
+++ b/src/Components/TranslationQuestion.jsx
@@ -26,9 +26,13 @@ const TranslationQuestion = ({ sentence, onNext }) => {
       }
     };
 
-    inputRef.current.addEventListener("keydown", handleKeyPress);
+    const currentInput = inputRef.current;
+
+    currentInput.addEventListener("keydown", handleKeyPress);
     return () => {
-      inputRef.current.removeEventListener("keydown", handleKeyPress);
+      if (inputRef.current) {
+        currentInput.removeEventListener("keydown", handleKeyPress);
+      }
     };
   });
 

--- a/src/Components/TranslationQuestion.jsx
+++ b/src/Components/TranslationQuestion.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from "react";
+import { Box, TextField, Button, Typography } from "@mui/material";
+import { useSnackbar } from "../Contexts/SnackbarContext";
+
+const TranslationQuestion = ({ sentence, onNext }) => {
+  const [userAnswer, setUserAnswer] = useState("");
+  const [isCorrect, setIsCorrect] = useState();
+  const { showSnackbar } = useSnackbar();
+
+  const possibleAnswers = sentence.possible_answers.map((answer) =>
+    answer.trim().toLowerCase(),
+  );
+
+  const checkAnswer = () => {
+    if (possibleAnswers.includes(userAnswer.trim().toLowerCase())) {
+      setIsCorrect(true);
+      showSnackbar("Correct!", "success");
+      setTimeout(onNext, 1000);
+    } else {
+      setIsCorrect(false);
+      showSnackbar("Incorrect", "error");
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        m: 2,
+        p: 2,
+        border: 1,
+        borderColor:
+          isCorrect != null && isCorrect
+            ? "success.main"
+            : isCorrect != null && !isCorrect
+              ? "error.main"
+              : "primary.main",
+        borderRadius: 2,
+      }}
+    >
+      <Typography variant="h6">{sentence.full_sentence}</Typography>
+      <TextField
+        label="Translate to English"
+        value={userAnswer}
+        onChange={(e) => setUserAnswer(e.target.value)}
+        sx={{ mt: 2, width: "100%" }}
+      />
+      <Button onClick={checkAnswer} variant="contained" sx={{ mt: 2 }}>
+        Submit
+      </Button>
+    </Box>
+  );
+};
+
+export default TranslationQuestion;

--- a/src/Routes/PracticeLesson.css
+++ b/src/Routes/PracticeLesson.css
@@ -1,0 +1,15 @@
+.fade-enter {
+    opacity: 0;
+}
+.fade-enter-active {
+    opacity: 1;
+    transition: opacity 300ms;
+
+}
+.fade-exit {
+    opacity: 1;
+}
+.fade-exit-active {
+    opacity: 0;
+    transition: opacity 300ms;
+}

--- a/src/Routes/PracticeLesson.css
+++ b/src/Routes/PracticeLesson.css
@@ -1,15 +1,29 @@
-.fade-enter {
-    opacity: 0;
+@keyframes slideIn {
+    from {
+        opacity: 0;
+        transform: translateX(50%);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
 }
-.fade-enter-active {
-    opacity: 1;
-    transition: opacity 300ms;
 
+@keyframes slideOut {
+    from {
+        opacity: 1;
+        transform: translateX(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateX(-50%);
+    }
 }
-.fade-exit {
-    opacity: 1;
+
+.slide-in {
+    animation: slideIn 300ms forwards;
 }
-.fade-exit-active {
-    opacity: 0;
-    transition: opacity 300ms;
+
+.slide-out {
+    animation: slideOut 200ms forwards;
 }

--- a/src/Routes/PracticeLesson.jsx
+++ b/src/Routes/PracticeLesson.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import { Box, Skeleton, Typography } from "@mui/material";
@@ -7,15 +7,16 @@ import { useAuth } from "../Contexts/AuthContext";
 import { useSnackbar } from "../Contexts/SnackbarContext";
 import { useTheme } from "@mui/material/styles";
 import TranslationQuestion from "../Components/TranslationQuestion";
-import { CSSTransition, TransitionGroup } from "react-transition-group";
 import "./PracticeLesson.css";
 
-const GrammarLesson = () => {
+const PracticeLesson = () => {
   const { lessonId } = useParams();
   const { auth } = useAuth();
   const { showSnackbar } = useSnackbar();
   const theme = useTheme();
   const [currentSentence, setCurrentSentence] = useState(0);
+  const [animationClass, setAnimationClass] = useState("slide-in");
+  const nodeRef = useRef(null);
 
   const {
     data: lesson,
@@ -38,13 +39,16 @@ const GrammarLesson = () => {
   });
 
   const handleNext = () => {
-    if (currentSentence === lesson.sentences.length - 1) {
-      showSnackbar("Lesson complete!", "success");
-    }
-
-    setCurrentSentence((prev) =>
-      prev === lesson.sentences.length - 1 ? 0 : prev + 1,
-    );
+    setAnimationClass("slide-out");
+    setTimeout(() => {
+      if (currentSentence === lesson.sentences.length - 1) {
+        showSnackbar("Lesson complete!", "success");
+      }
+      setCurrentSentence((prev) =>
+        prev === lesson.sentences.length - 1 ? 0 : prev + 1,
+      );
+      setAnimationClass("slide-in");
+    }, 400);
   };
 
   if (isLoading) {
@@ -75,23 +79,23 @@ const GrammarLesson = () => {
         alignItems: "center",
         justifyContent: "center",
         margin: "auto",
-        mt: 4,
-        p: 1.5,
+        mt: 6,
+        p: 3,
+        pb: "6em",
         border: 2,
         borderColor: "primary.main",
         borderRadius: 2,
       }}
     >
-      <TransitionGroup>
-        <CSSTransition timeout={1000} classNames={"fade"} key={currentSentence}>
-          <TranslationQuestion
-            sentence={lesson.sentences[currentSentence]}
-            onNext={handleNext}
-          />
-        </CSSTransition>
-      </TransitionGroup>
+      <Typography variant={"h4"}>{lesson.title}</Typography>
+      <div ref={nodeRef} className={animationClass}>
+        <TranslationQuestion
+          sentence={lesson.sentences[currentSentence]}
+          onNext={handleNext}
+        />
+      </div>
     </Box>
   );
 };
 
-export default GrammarLesson;
+export default PracticeLesson;

--- a/src/Routes/PracticeLesson.jsx
+++ b/src/Routes/PracticeLesson.jsx
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { Box, Skeleton, Typography } from "@mui/material";
+import { useParams } from "react-router-dom";
+import { useAuth } from "../Contexts/AuthContext";
+import { useSnackbar } from "../Contexts/SnackbarContext";
+import { useTheme } from "@mui/material/styles";
+import TranslationQuestion from "../Components/TranslationQuestion";
+import { CSSTransition, TransitionGroup } from "react-transition-group";
+import "./PracticeLesson.css";
+
+const GrammarLesson = () => {
+  const { lessonId } = useParams();
+  const { auth } = useAuth();
+  const { showSnackbar } = useSnackbar();
+  const theme = useTheme();
+  const [currentSentence, setCurrentSentence] = useState(0);
+
+  const {
+    data: lesson,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ["lesson", lessonId, auth.token],
+    queryFn: async () => {
+      const response = await axios.get(
+        `${process.env.REACT_APP_API_BASE}/api/lessons/${lessonId}`,
+        {
+          headers: { Authorization: `Bearer ${auth.token}` },
+        },
+      );
+      return response.data;
+    },
+    onError: () => {
+      showSnackbar("Failed to fetch lesson", "error");
+    },
+  });
+
+  const handleNext = () => {
+    if (currentSentence === lesson.sentences.length - 1) {
+      showSnackbar("Lesson complete!", "success");
+    }
+
+    setCurrentSentence((prev) =>
+      prev === lesson.sentences.length - 1 ? 0 : prev + 1,
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          mt: 4,
+        }}
+      >
+        <Skeleton variant="rectangular" width="80%" height={200} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return <Typography>Error loading lesson.</Typography>;
+  }
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        width: "80%",
+        alignItems: "center",
+        justifyContent: "center",
+        margin: "auto",
+        mt: 4,
+        p: 1.5,
+        border: 2,
+        borderColor: "primary.main",
+        borderRadius: 2,
+      }}
+    >
+      <TransitionGroup>
+        <CSSTransition timeout={1000} classNames={"fade"} key={currentSentence}>
+          <TranslationQuestion
+            sentence={lesson.sentences[currentSentence]}
+            onNext={handleNext}
+          />
+        </CSSTransition>
+      </TransitionGroup>
+    </Box>
+  );
+};
+
+export default GrammarLesson;

--- a/src/Routes/PracticeLesson.jsx
+++ b/src/Routes/PracticeLesson.jsx
@@ -1,11 +1,10 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import { Box, Skeleton, Typography } from "@mui/material";
 import { useParams } from "react-router-dom";
 import { useAuth } from "../Contexts/AuthContext";
 import { useSnackbar } from "../Contexts/SnackbarContext";
-import { useTheme } from "@mui/material/styles";
 import TranslationQuestion from "../Components/TranslationQuestion";
 import "./PracticeLesson.css";
 
@@ -13,7 +12,6 @@ const PracticeLesson = () => {
   const { lessonId } = useParams();
   const { auth } = useAuth();
   const { showSnackbar } = useSnackbar();
-  const theme = useTheme();
   const [currentSentence, setCurrentSentence] = useState(0);
   const [animationClass, setAnimationClass] = useState("slide-in");
   const nodeRef = useRef(null);
@@ -38,6 +36,7 @@ const PracticeLesson = () => {
     },
   });
 
+  // Event handler for switching to the next sentence
   const handleNext = () => {
     setAnimationClass("slide-out");
     setTimeout(() => {


### PR DESCRIPTION
### Brief Description
<!-- Describe the purpose of this pull request -->
In this pull request, I made a page dedicated to showing practice lessons where users translate sentences into English.
### Changes
<!-- Describe the changes made in this pull request -->
- There is now a PracticeLesson page that will show when a given lesson's category is "practice"
- There is now a TranslationQuestion component that will show and check a text input for the user's translation
- There are animations for changing questions and hovering over the input

### Screenshots (if applicable)
<!-- Add screenshots to help showcase your changes -->
![image](https://github.com/user-attachments/assets/3f51c6e4-bcfb-4ed7-ad5c-867bf7f05a0c)
