### PR TITLE
Update admin lesson table

### DIFF
--- a/src/Components/MarkdownPreviewer.js
+++ b/src/Components/MarkdownPreviewer.js
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import { MuiMarkdown } from "mui-markdown";
+import { Box, TextField, Grid } from "@mui/material";
+
+const MarkdownPreviewer = ({ value, onChange }) => {
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={6}>
+        <TextField
+          label="Content"
+          value={value}
+          onChange={onChange}
+          multiline
+          minRows={10}
+          maxRows={20}
+          variant="outlined"
+          fullWidth
+        />
+      </Grid>
+      <Grid item xs={6}>
+        <Box
+          sx={{
+            border: "1px solid #ccc",
+            padding: 2,
+            height: "100%",
+            overflowY: "auto",
+          }}
+        >
+          <MuiMarkdown>{value}</MuiMarkdown>
+        </Box>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default MarkdownPreviewer;

--- a/src/Components/MarkdownPreviewer.js
+++ b/src/Components/MarkdownPreviewer.js
@@ -21,8 +21,10 @@ const MarkdownPreviewer = ({ value, onChange }) => {
         <Box
           sx={{
             border: "1px solid #ccc",
+            borderRadius: 2,
             padding: 2,
             height: "100%",
+            maxHeight: 492,
             overflowY: "auto",
           }}
         >

--- a/src/Components/NewLessonForm.js
+++ b/src/Components/NewLessonForm.js
@@ -3,6 +3,9 @@ import {
   Autocomplete,
   Box,
   Button,
+  Card,
+  CardContent,
+  CardActions,
   TextField,
   Typography,
 } from "@mui/material";
@@ -24,9 +27,37 @@ const NewLessonForm = ({ cards, sections, onSubmit }) => {
       section_id: "",
       category: "",
       content: "",
-      sentences: [{ full_sentence: "", possible_answers: [] }],
+      sentences: [],
       card_ids: [],
     });
+  };
+
+  const handleSentenceChange = (index, field, value) => {
+    const updatedSentences = [...newLesson.sentences];
+    updatedSentences[index][field] = value;
+    setNewLesson({ ...newLesson, sentences: updatedSentences });
+  };
+
+  const handlePossibleAnswerChange = (sentenceIndex, answerIndex, value) => {
+    const updatedSentences = [...newLesson.sentences];
+    updatedSentences[sentenceIndex].possible_answers[answerIndex] = value;
+    setNewLesson({ ...newLesson, sentences: updatedSentences });
+  };
+
+  const addNewSentence = () => {
+    setNewLesson({
+      ...newLesson,
+      sentences: [
+        ...newLesson.sentences,
+        { full_sentence: "", possible_answers: [""] },
+      ],
+    });
+  };
+
+  const addNewPossibleAnswer = (sentenceIndex) => {
+    const updatedSentences = [...newLesson.sentences];
+    updatedSentences[sentenceIndex].possible_answers.push("");
+    setNewLesson({ ...newLesson, sentences: updatedSentences });
   };
 
   return (
@@ -104,6 +135,58 @@ const NewLessonForm = ({ cards, sections, onSubmit }) => {
           />
         )}
 
+        {newLesson.category === "practice" && (
+          <Box sx={{ mb: 2, width: "300px" }}>
+            {newLesson.sentences.map((sentence, sentenceIndex) => (
+              <Card key={sentenceIndex} sx={{ mb: 2 }}>
+                <CardContent>
+                  <TextField
+                    label="Full Sentence"
+                    value={sentence.full_sentence}
+                    onChange={(e) =>
+                      handleSentenceChange(
+                        sentenceIndex,
+                        "full_sentence",
+                        e.target.value,
+                      )
+                    }
+                    sx={{ mb: 1, width: "100%" }}
+                    required
+                  />
+                  {sentence.possible_answers.map((answer, answerIndex) => (
+                    <TextField
+                      key={answerIndex}
+                      label={`Possible Answer ${answerIndex + 1}`}
+                      value={answer}
+                      onChange={(e) =>
+                        handlePossibleAnswerChange(
+                          sentenceIndex,
+                          answerIndex,
+                          e.target.value,
+                        )
+                      }
+                      sx={{ mb: 1, width: "100%" }}
+                      required
+                    />
+                  ))}
+                </CardContent>
+                <CardActions>
+                  <Button
+                    variant="outlined"
+                    onClick={() => addNewPossibleAnswer(sentenceIndex)}
+                    sx={{ mb: 1 }}
+                  >
+                    Add Possible Answer
+                  </Button>
+                </CardActions>
+              </Card>
+            ))}
+            <Button variant="outlined" onClick={addNewSentence}>
+              Add New Sentence
+            </Button>
+          </Box>
+        )}
+
         {newLesson.category === "flashcards" && (
           <Autocomplete
             multiple
@@ -127,7 +210,7 @@ const NewLessonForm = ({ cards, sections, onSubmit }) => {
         )}
 
         <Button variant="contained" color="primary" onClick={handleAddLesson}>
-          Add Card
+          Add Lesson
         </Button>
       </Box>
     </Box>

--- a/src/Components/NewLessonForm.js
+++ b/src/Components/NewLessonForm.js
@@ -4,8 +4,8 @@ import {
   Box,
   Button,
   Card,
-  CardContent,
   CardActions,
+  CardContent,
   TextField,
   Typography,
 } from "@mui/material";

--- a/src/Components/NewLessonForm.js
+++ b/src/Components/NewLessonForm.js
@@ -9,6 +9,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import MarkdownPreviewer from "./MarkdownPreviewer";
 
 const NewLessonForm = ({ cards, sections, onSubmit }) => {
   const [newLesson, setNewLesson] = useState({
@@ -123,16 +124,17 @@ const NewLessonForm = ({ cards, sections, onSubmit }) => {
         />
 
         {newLesson.category === "grammar" && (
-          <TextField
-            label="Content"
-            value={newLesson.content}
-            onChange={(e) =>
-              setNewLesson({ ...newLesson, content: e.target.value })
-            }
-            sx={{ mb: 2, width: "300px" }}
-            required
-            multiline
-          />
+          <Box sx={{ width: 600, mb: 2 }}>
+            <Typography variant="h6" gutterBottom textAlign={"center"}>
+              Add Content
+            </Typography>
+            <MarkdownPreviewer
+              value={newLesson.content}
+              onChange={(e) =>
+                setNewLesson({ ...newLesson, content: e.target.value })
+              }
+            />
+          </Box>
         )}
 
         {newLesson.category === "practice" && (

--- a/src/Components/NewLessonForm.js
+++ b/src/Components/NewLessonForm.js
@@ -11,12 +11,22 @@ const NewLessonForm = ({ cards, sections, onSubmit }) => {
   const [newLesson, setNewLesson] = useState({
     title: "",
     section_id: "",
+    category: "",
+    content: "",
+    sentences: [],
     card_ids: [],
   });
 
   const handleAddLesson = () => {
     onSubmit(newLesson);
-    setNewLesson({ title: "", section_id: "", card_ids: [] });
+    setNewLesson({
+      title: "",
+      section_id: "",
+      category: "",
+      content: "",
+      sentences: [{ full_sentence: "", possible_answers: [] }],
+      card_ids: [],
+    });
   };
 
   return (
@@ -69,24 +79,53 @@ const NewLessonForm = ({ cards, sections, onSubmit }) => {
           )}
           sx={{ mb: 2, width: "300px" }}
         />
-
         <Autocomplete
-          multiple
-          disableCloseOnSelect
-          options={cards}
-          getOptionLabel={(option) => option.front_text}
-          value={cards.filter((card) => newLesson.card_ids?.includes(card._id))}
+          options={["grammar", "flashcards", "practice"]}
+          value={newLesson.category}
           onChange={(event, newValue) => {
-            setNewLesson({
-              ...newLesson,
-              card_ids: newValue.map((card) => card._id),
-            });
+            setNewLesson({ ...newLesson, category: newValue });
           }}
           renderInput={(params) => (
-            <TextField {...params} label="Cards" variant="outlined" />
+            <TextField {...params} label="Category" variant="outlined" />
           )}
           sx={{ mb: 2, width: "300px" }}
         />
+
+        {newLesson.category === "grammar" && (
+          <TextField
+            label="Content"
+            value={newLesson.content}
+            onChange={(e) =>
+              setNewLesson({ ...newLesson, content: e.target.value })
+            }
+            sx={{ mb: 2, width: "300px" }}
+            required
+            multiline
+          />
+        )}
+
+        {newLesson.category === "flashcards" && (
+          <Autocomplete
+            multiple
+            disableCloseOnSelect
+            options={cards}
+            getOptionLabel={(option) => option.front_text}
+            value={cards.filter((card) =>
+              newLesson.card_ids?.includes(card._id),
+            )}
+            onChange={(event, newValue) => {
+              setNewLesson({
+                ...newLesson,
+                card_ids: newValue.map((card) => card._id),
+              });
+            }}
+            renderInput={(params) => (
+              <TextField {...params} label="Cards" variant="outlined" />
+            )}
+            sx={{ mb: 2, width: "300px" }}
+          />
+        )}
+
         <Button variant="contained" color="primary" onClick={handleAddLesson}>
           Add Card
         </Button>

--- a/src/Routes/AdminLessonTable.js
+++ b/src/Routes/AdminLessonTable.js
@@ -20,6 +20,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import MarkdownPreviewer from "../Components/MarkdownPreviewer";
 
 const AdminLessonTable = () => {
   const { auth } = useAuth();
@@ -299,9 +300,10 @@ const AdminLessonTable = () => {
                 <TableCell
                   sx={{ width: 300, maxHeight: 150, overflowY: "auto" }}
                 >
-                  {editingLessonId === lesson._id ? (
-                    <TextField
-                      label="Content"
+                  {editingLessonId === lesson._id &&
+                  lesson.category === "grammar" ? (
+                    <MarkdownPreviewer
+                      sx={{ width: 600, height: 100, mb: 2 }}
                       value={editedLesson.content}
                       onChange={(e) =>
                         setEditedLesson({
@@ -309,13 +311,6 @@ const AdminLessonTable = () => {
                           content: e.target.value,
                         })
                       }
-                      sx={{
-                        mb: 2,
-                        width: "300px",
-                      }}
-                      required
-                      multiline
-                      maxRows={10}
                     />
                   ) : (
                     <Box

--- a/src/Routes/AdminLessonTable.js
+++ b/src/Routes/AdminLessonTable.js
@@ -221,6 +221,7 @@ const AdminLessonTable = () => {
               <TableCell>ID</TableCell>
               <TableCell>Title</TableCell>
               <TableCell>Section Name</TableCell>
+              <TableCell>Category</TableCell>
               <TableCell>Cards</TableCell>
               <TableCell>Actions</TableCell>
             </TableRow>
@@ -268,6 +269,24 @@ const AdminLessonTable = () => {
                     sections.find(
                       (section) => section._id === lesson.section_id,
                     )?.name
+                  )}
+                </TableCell>
+                <TableCell sx={{ width: 300 }}>
+                  {editingLessonId === lesson._id ? (
+                    <TextField
+                      label="Category"
+                      value={editedLesson.category}
+                      onChange={(e) =>
+                        setEditedLesson({
+                          ...editedLesson,
+                          category: e.target.value,
+                        })
+                      }
+                      sx={{ mb: 2, width: "300px" }}
+                      required
+                    />
+                  ) : (
+                    lesson.category
                   )}
                 </TableCell>
                 <TableCell sx={{ width: 300 }}>

--- a/src/Routes/AdminLessonTable.js
+++ b/src/Routes/AdminLessonTable.js
@@ -8,6 +8,8 @@ import {
   Autocomplete,
   Box,
   Button,
+  Card,
+  CardContent,
   Skeleton,
   Table,
   TableBody,
@@ -213,7 +215,7 @@ const AdminLessonTable = () => {
         onSubmit={handleAddLesson}
       />
       <TableContainer
-        sx={{ maxWidth: "90%", borderRadius: 2, border: `1px solid` }}
+        sx={{ maxWidth: "95%", borderRadius: 2, border: `1px solid` }}
       >
         <Table sx={{ minWidth: 700 }}>
           <TableHead>
@@ -222,6 +224,8 @@ const AdminLessonTable = () => {
               <TableCell>Title</TableCell>
               <TableCell>Section Name</TableCell>
               <TableCell>Category</TableCell>
+              <TableCell>Content</TableCell>
+              <TableCell>Sentences</TableCell>
               <TableCell>Cards</TableCell>
               <TableCell>Actions</TableCell>
             </TableRow>
@@ -234,7 +238,7 @@ const AdminLessonTable = () => {
               >
                 <TableCell
                   sx={{
-                    maxWidth: 100,
+                    maxWidth: 50,
                     overflow: "hidden",
                     textOverflow: "ellipsis",
                     whiteSpace: "nowrap",
@@ -243,6 +247,7 @@ const AdminLessonTable = () => {
                   {lesson._id}
                 </TableCell>
                 <TableCell>{lesson.title}</TableCell>
+                {/* Sections Column */}
                 <TableCell sx={{ width: 300 }}>
                   {editingLessonId === lesson._id ? (
                     <Autocomplete
@@ -271,6 +276,7 @@ const AdminLessonTable = () => {
                     )?.name
                   )}
                 </TableCell>
+                {/* Category Column */}
                 <TableCell sx={{ width: 300 }}>
                   {editingLessonId === lesson._id ? (
                     <TextField
@@ -289,6 +295,43 @@ const AdminLessonTable = () => {
                     lesson.category
                   )}
                 </TableCell>
+                {/* Content Column */}
+                <TableCell sx={{ width: 300 }}>
+                  {editingLessonId === lesson._id ? (
+                    <TextField
+                      label="Content"
+                      value={editedLesson.content}
+                      onChange={(e) =>
+                        setEditedLesson({
+                          ...editedLesson,
+                          content: e.target.value,
+                        })
+                      }
+                      sx={{ mb: 2, width: "300px" }}
+                      required
+                      multiline
+                    />
+                  ) : (
+                    lesson.content
+                  )}
+                </TableCell>
+
+                {/* Sentences Column */}
+                <TableCell sx={{ width: 300 }}>
+                  {/*  TODO: Add sentences column for updating, consider reworking the db to include Sentence models as their own collection, similar to cards */}
+                  {/*  For now we'll just show the full text for each sentence */}
+                  {lesson.sentences.map((sentence, sentenceIndex) => (
+                    <Card key={sentenceIndex} sx={{ mb: 2 }}>
+                      <CardContent>
+                        <Typography variant="h6" gutterBottom>
+                          {sentence.full_sentence}
+                        </Typography>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </TableCell>
+
+                {/* Cards Column */}
                 <TableCell sx={{ width: 300 }}>
                   {editingLessonId === lesson._id ? (
                     <Autocomplete

--- a/src/Routes/AdminLessonTable.js
+++ b/src/Routes/AdminLessonTable.js
@@ -277,7 +277,7 @@ const AdminLessonTable = () => {
                   )}
                 </TableCell>
                 {/* Category Column */}
-                <TableCell sx={{ width: 300 }}>
+                <TableCell sx={{ width: 150 }}>
                   {editingLessonId === lesson._id ? (
                     <TextField
                       label="Category"
@@ -288,7 +288,7 @@ const AdminLessonTable = () => {
                           category: e.target.value,
                         })
                       }
-                      sx={{ mb: 2, width: "300px" }}
+                      sx={{ mb: 2, minWidth: 120 }}
                       required
                     />
                   ) : (
@@ -296,7 +296,9 @@ const AdminLessonTable = () => {
                   )}
                 </TableCell>
                 {/* Content Column */}
-                <TableCell sx={{ width: 300 }}>
+                <TableCell
+                  sx={{ width: 300, maxHeight: 150, overflowY: "auto" }}
+                >
                   {editingLessonId === lesson._id ? (
                     <TextField
                       label="Content"
@@ -307,19 +309,30 @@ const AdminLessonTable = () => {
                           content: e.target.value,
                         })
                       }
-                      sx={{ mb: 2, width: "300px" }}
+                      sx={{
+                        mb: 2,
+                        width: "300px",
+                      }}
                       required
                       multiline
+                      maxRows={10}
                     />
                   ) : (
-                    lesson.content
+                    <Box
+                      sx={{
+                        maxHeight: 150,
+                        overflowY: "auto",
+                      }}
+                    >
+                      {lesson.content}
+                    </Box>
                   )}
                 </TableCell>
 
                 {/* Sentences Column */}
                 <TableCell sx={{ width: 300 }}>
                   {/*  TODO: Add sentences column for updating, consider reworking the db to include Sentence models as their own collection, similar to cards */}
-                  {/*  For now we'll just show the full text for each sentence */}
+                  {/*  For now, we'll just show the full text for each sentence */}
                   {lesson.sentences.map((sentence, sentenceIndex) => (
                     <Card key={sentenceIndex} sx={{ mb: 2 }}>
                       <CardContent>


### PR DESCRIPTION
### Brief Description
<!-- Describe the purpose of this pull request -->
In this pull request, I updated the admin's lesson table to reflect changes in the lesson model.
### Changes
<!-- Describe the changes made in this pull request -->
- There are now columns for the new attributes (category, content, and sentences)
- There is now a markdown previewer component that takes markdown input on the left side, and shows what it would look like on the right side
- The NewLessonForm dynamically changes depending on what category of lesson is being made
  - For grammar lessons, the markdown previewer is rendered
  - For practice lessons, smaller sentence forms are rendered
  - For flashcard lessons, the preexisting cards Autocomplete is rendered
- When updating a grammar lesson, the table renders the markdown previewer

### Screenshots (if applicable)
<!-- Add screenshots to help showcase your changes -->
- Before selecting a category
![image](https://github.com/user-attachments/assets/f1410409-c04a-4ff7-8311-4ef1ab5a9795)

- Making a new Grammar lesson
![image](https://github.com/user-attachments/assets/6eba3c75-5a32-46f5-8a6f-5d9bdec83a28)

- Making a new Practice lesson
![image](https://github.com/user-attachments/assets/c6620f30-f3ef-4057-8ede-23a8197fd9e2)
