### PR TITLE
Migrate auth to react query

### DIFF
--- a/src/Components/FlashcardList.js
+++ b/src/Components/FlashcardList.js
@@ -15,7 +15,7 @@ import Flashcard from "./Flashcard";
 import { useTheme } from "@mui/material/styles";
 
 const FlashcardList = ({ lessonId }) => {
-  const { auth } = useAuth();
+  const { authData } = useAuth();
   const { showSnackbar } = useSnackbar();
   const [currentCardIndex, setCurrentCardIndex] = useState(0);
   const [showTranslation, setShowTranslation] = useState(false);
@@ -28,13 +28,14 @@ const FlashcardList = ({ lessonId }) => {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ["flashcards", lessonId, auth.token],
+    queryKey: ["flashcards", lessonId, authData?.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/cards/lesson/${lessonId}`,
       );
       return response.data;
     },
+    enabled: !!authData,
   });
 
   useEffect(() => {
@@ -102,50 +103,58 @@ const FlashcardList = ({ lessonId }) => {
         mt: 4,
       }}
     >
-      <Flashcard
-        frontText={
-          isEnglishToJapanese ? currentCard?.back_text : currentCard?.front_text
-        }
-        backText={
-          isEnglishToJapanese ? currentCard?.front_text : currentCard?.back_text
-        }
-        showTranslation={showTranslation}
-        onShowTranslation={handleShowTranslation}
-        onNextCard={handleNextCard}
-      />
-      <Stack
-        direction={"row"}
-        sx={{ display: "flex", width: "90%", alignItems: "center" }}
-      >
-        <LinearProgress
-          variant="determinate"
-          value={
-            // Keep the progress at 100% if they finished, but allow them to keep reviewing
-            hasFinished ? 100 : (currentCardIndex / flashcards.length) * 100
-          }
-          sx={{
-            width: "95%",
-            height: 5,
-            borderRadius: 2,
-            mt: 1.1,
-            "& .MuiLinearProgress-bar": {
-              background: `linear-gradient(to right, ${theme.palette.primary.main}, ${theme.palette.secondary.dark})`,
-            },
-          }}
-        />
-        <Zoom in={hasFinished} easing={"ease"} timeout={500}>
-          <Typography
-            sx={{
-              mt: 0.8,
-              color: "transparent",
-              textShadow: `0 0 0 ${theme.palette.secondary.dark}`,
-            }}
-            variant={"h5"}
+      {authData && (
+        <>
+          <Flashcard
+            frontText={
+              isEnglishToJapanese
+                ? currentCard?.back_text
+                : currentCard?.front_text
+            }
+            backText={
+              isEnglishToJapanese
+                ? currentCard?.front_text
+                : currentCard?.back_text
+            }
+            showTranslation={showTranslation}
+            onShowTranslation={handleShowTranslation}
+            onNextCard={handleNextCard}
+          />
+          <Stack
+            direction={"row"}
+            sx={{ display: "flex", width: "90%", alignItems: "center" }}
           >
-            🔥
-          </Typography>
-        </Zoom>
-      </Stack>
+            <LinearProgress
+              variant="determinate"
+              value={
+                // Keep the progress at 100% if they finished, but allow them to keep reviewing
+                hasFinished ? 100 : (currentCardIndex / flashcards.length) * 100
+              }
+              sx={{
+                width: "95%",
+                height: 5,
+                borderRadius: 2,
+                mt: 1.1,
+                "& .MuiLinearProgress-bar": {
+                  background: `linear-gradient(to right, ${theme.palette.primary.main}, ${theme.palette.secondary.dark})`,
+                },
+              }}
+            />
+            <Zoom in={hasFinished} easing={"ease"} timeout={500}>
+              <Typography
+                sx={{
+                  mt: 0.8,
+                  color: "transparent",
+                  textShadow: `0 0 0 ${theme.palette.secondary.dark}`,
+                }}
+                variant={"h5"}
+              >
+                🔥
+              </Typography>
+            </Zoom>
+          </Stack>
+        </>
+      )}
     </Box>
   );
 };

--- a/src/Components/NavBar.js
+++ b/src/Components/NavBar.js
@@ -20,7 +20,7 @@ import { DarkMode, LightMode, Menu as MenuIcon } from "@mui/icons-material";
 import { useAuth } from "../Contexts/AuthContext";
 
 function NavBar(props) {
-  const { auth, logout, authIsLoading } = useAuth();
+  const { logout, authIsLoading, authData } = useAuth();
   const theme = useTheme();
   const navigate = useNavigate();
   const [anchorElMenu, setAnchorElMenu] = useState(null);
@@ -45,10 +45,10 @@ function NavBar(props) {
   }, []);
 
   useEffect(() => {
-    if (auth.isAdmin) {
+    if (authData && authData.isAdmin) {
       pages.push(...adminPages);
     }
-  }, [adminPages, auth.isAdmin, pages]);
+  }, [adminPages, authData, pages]);
 
   const handleMenuOpen = (event) => {
     setAnchorElMenu(event.currentTarget);
@@ -125,7 +125,7 @@ function NavBar(props) {
           </Icon>
           {authIsLoading ? (
             <Skeleton variant="circular" width={40} height={40} />
-          ) : auth.isLoggedIn ? (
+          ) : authData.isLoggedIn ? (
             <>
               <IconButton onClick={handleProfileMenuOpen} sx={{ mt: 0.5 }}>
                 <Avatar
@@ -134,7 +134,7 @@ function NavBar(props) {
                     color: theme.palette.primary.contrastText,
                   }}
                 >
-                  {auth.username ? auth.username[0].toUpperCase() : "?"}
+                  {authData.username ? authData.username[0].toUpperCase() : "?"}
                 </Avatar>
               </IconButton>
               <Menu

--- a/src/Components/ProtectedRoute.js
+++ b/src/Components/ProtectedRoute.js
@@ -6,11 +6,11 @@ import { Box, Skeleton, Typography } from "@mui/material";
 import { useQuery } from "@tanstack/react-query";
 
 const ProtectedRoute = ({ children }) => {
-  const { auth, checkAdmin } = useAuth();
+  const { authData, checkAdmin } = useAuth();
   const { showSnackbar } = useSnackbar();
   const navigate = useNavigate();
 
-  const token = auth.token || localStorage.getItem("token");
+  const token = authData?.token || localStorage.getItem("token");
   const {
     data: isAdmin,
     isLoading,

--- a/src/Contexts/AuthContext.js
+++ b/src/Contexts/AuthContext.js
@@ -1,13 +1,8 @@
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-} from "react";
+import React, { createContext, useCallback, useContext, useState } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import { useSnackbar } from "./SnackbarContext";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 const AuthContext = createContext();
 
@@ -22,76 +17,77 @@ export const AuthProvider = ({ children }) => {
   });
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
-  const [authIsLoading, setAuthIsLoading] = useState(true);
+  const queryClient = useQueryClient();
 
-  const checkAdmin = useCallback(async () => {
-    try {
-      const token = auth.token || localStorage.getItem("token");
-      const response = await axios.get(
-        `${process.env.REACT_APP_API_BASE}/api/auth/check-admin`,
-        {
-          headers: { Authorization: `Bearer ${token}` },
-        },
-      );
-      return new Promise((resolve) => {
-        setAuth((prevAuth) => {
-          resolve(response.data.isAdmin);
-          return {
-            ...prevAuth,
-            isAdmin: response.data.isAdmin,
-          };
-        });
-      });
-    } catch (error) {
-      if (error.response.status === 401) {
+  const fetchAuthState = async () => {
+    const token = localStorage.getItem("token");
+    console.log("fetchAuthState token", token);
+    if (!token) {
+      return { isLoggedIn: false, isAdmin: false, token: "", username: "" };
+    }
+    const response = await axios.get(
+      `${process.env.REACT_APP_API_BASE}/api/auth/check-admin`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    if (response.status >= 400) {
+      return { isLoggedIn: false, isAdmin: false, token: "", username: "" };
+    }
+    return {
+      token,
+      isLoggedIn: true,
+      isAdmin: response.data.isAdmin,
+      username: localStorage.getItem("username"),
+    };
+  };
+
+  const { data: authData, isLoading: authIsLoading } = useQuery({
+    queryKey: ["authState"],
+    queryFn: fetchAuthState,
+    onError: (error) => {
+      if (error.response?.status === 401) {
         showSnackbar("You've been logged out, please sign in again.", "error");
         logout(() => navigate("/login"));
       }
-      return Promise.resolve(false);
-    } finally {
-      setAuthIsLoading(false);
-    }
-  }, [auth.token, navigate, showSnackbar]);
-
-  useEffect(() => {
-    const token = localStorage.getItem("token");
-    const username = localStorage.getItem("username");
-    if (token) {
-      checkAdmin().then((isAdmin) => {
-        setAuth({
-          token: token,
-          isLoggedIn: true,
-          isAdmin: isAdmin,
-          username: username,
-        });
-      });
-    } else {
-      setAuthIsLoading(false);
-    }
-  }, [checkAdmin]);
+    },
+    onSuccess: (data) => {
+      console.dir(data);
+    },
+  });
 
   const login = (data, callback) => {
     localStorage.setItem("token", data.token);
     localStorage.setItem("username", data.username);
-    setAuth({
-      token: data.token,
-      isLoggedIn: true,
-      isAdmin: data.isAdmin,
-      username: data.username,
-    });
+    queryClient.invalidateQueries("authState");
     if (callback) callback();
   };
 
   const logout = (callback) => {
     localStorage.removeItem("token");
     localStorage.removeItem("username");
-    setAuth({ token: "", isLoggedIn: false, isAdmin: false, username: "" });
+    queryClient.invalidateQueries("authState");
     if (callback) callback();
   };
 
+  const checkAdmin = useCallback(async () => {
+    const token = localStorage.getItem("token");
+    if (token) {
+      const response = await axios.get(
+        `${process.env.REACT_APP_API_BASE}/api/auth/check-admin`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+      return response.data.isAdmin;
+    }
+    return false;
+  }, []);
+
   return (
     <AuthContext.Provider
-      value={{ auth, authIsLoading, login, logout, checkAdmin }}
+      value={{ auth, authIsLoading, authData, login, logout, checkAdmin }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/Contexts/AuthContext.js
+++ b/src/Contexts/AuthContext.js
@@ -9,19 +9,12 @@ const AuthContext = createContext();
 export const useAuth = () => useContext(AuthContext);
 
 export const AuthProvider = ({ children }) => {
-  const [auth, setAuth] = useState({
-    token: "",
-    isLoggedIn: false,
-    isAdmin: false,
-    username: "",
-  });
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
   const queryClient = useQueryClient();
 
   const fetchAuthState = async () => {
     const token = localStorage.getItem("token");
-    console.log("fetchAuthState token", token);
     if (!token) {
       return { isLoggedIn: false, isAdmin: false, token: "", username: "" };
     }
@@ -87,7 +80,7 @@ export const AuthProvider = ({ children }) => {
 
   return (
     <AuthContext.Provider
-      value={{ auth, authIsLoading, authData, login, logout, checkAdmin }}
+      value={{ authIsLoading, authData, login, logout, checkAdmin }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/Routes/AdminCardTable.js
+++ b/src/Routes/AdminCardTable.js
@@ -20,7 +20,7 @@ import {
 import NewCardForm from "../Components/NewCardForm";
 
 const AdminCardTable = () => {
-  const { auth } = useAuth();
+  const { authData, authIsLoading } = useAuth();
   const { showSnackbar } = useSnackbar();
   const [editingCardId, setEditingCardId] = useState(null);
   const [editedCard, setEditedCard] = useState({});
@@ -31,12 +31,12 @@ const AdminCardTable = () => {
     isLoading: isLoadingCards,
     isError: isErrorCards,
   } = useQuery({
-    queryKey: ["cards", auth.token],
+    queryKey: ["cards", authData?.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/cards/all`,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
 
@@ -45,6 +45,7 @@ const AdminCardTable = () => {
     onError: () => {
       showSnackbar("Failed to fetch cards", "error");
     },
+    enabled: !!authData,
   });
 
   const {
@@ -52,7 +53,7 @@ const AdminCardTable = () => {
     isLoading: isLoadingLessonGroups,
     isError: isErrorLessonGroups,
   } = useQuery({
-    queryKey: ["lessonGroups", auth.token],
+    queryKey: ["lessonGroups", authData?.token],
     queryFn: async () => {
       const [lessonsResponse, sectionsResponse] = await Promise.all([
         axios.get(`${process.env.REACT_APP_API_BASE}/api/lessons/all`),
@@ -75,6 +76,7 @@ const AdminCardTable = () => {
 
       return { groupedLessons, lessons, sections };
     },
+    enabled: !!authData,
   });
 
   const handleEdit = (card) => {
@@ -84,18 +86,17 @@ const AdminCardTable = () => {
 
   const updateMutation = useMutation({
     mutationFn: async () => {
-      console.dir(editedCard);
       await axios.put(
         `${process.env.REACT_APP_API_BASE}/api/cards/update/${editingCardId}`,
         editedCard,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
     },
     onSuccess: () => {
       showSnackbar("Card updated successfully", "success");
-      queryClient.invalidateQueries(["cards", auth.token]);
+      queryClient.invalidateQueries(["cards", authData.token]);
       setEditingCardId(null);
     },
     onError: () => {
@@ -112,13 +113,13 @@ const AdminCardTable = () => {
       await axios.delete(
         `${process.env.REACT_APP_API_BASE}/api/cards/delete/${cardId}`,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
     },
     onSuccess: () => {
       showSnackbar("Card deleted successfully", "success");
-      queryClient.invalidateQueries(["cards", auth.token]);
+      queryClient.invalidateQueries(["cards", authData.token]);
     },
     onError: () => {
       showSnackbar("Failed to delete card", "error");
@@ -135,13 +136,13 @@ const AdminCardTable = () => {
         `${process.env.REACT_APP_API_BASE}/api/cards/create`,
         newCard,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
     },
     onSuccess: () => {
       showSnackbar("Card added successfully", "success");
-      queryClient.invalidateQueries(["cards", auth.token]);
+      queryClient.invalidateQueries(["cards", authData.token]);
     },
     onError: () => {
       showSnackbar("Failed to add card", "error");
@@ -157,7 +158,7 @@ const AdminCardTable = () => {
     addMutation.mutate(newCard);
   };
 
-  if (isLoadingCards || isLoadingLessonGroups) {
+  if (isLoadingCards || isLoadingLessonGroups || authIsLoading) {
     return (
       <Box
         sx={{

--- a/src/Routes/AdminLessonTable.js
+++ b/src/Routes/AdminLessonTable.js
@@ -23,7 +23,7 @@ import {
 import MarkdownPreviewer from "../Components/MarkdownPreviewer";
 
 const AdminLessonTable = () => {
-  const { auth } = useAuth();
+  const { authData } = useAuth();
   const { showSnackbar } = useSnackbar();
   const [editingLessonId, setEditingLessonId] = useState(null);
   const [editedLesson, setEditedLesson] = useState({});
@@ -34,7 +34,7 @@ const AdminLessonTable = () => {
     isLoadingLessons,
     isErrorLessons,
   } = useQuery({
-    queryKey: ["lessons", auth.token],
+    queryKey: ["lessons", authData?.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/lessons/all`,
@@ -42,6 +42,7 @@ const AdminLessonTable = () => {
 
       return response.data;
     },
+    enabled: !!authData,
   });
 
   const {
@@ -49,7 +50,7 @@ const AdminLessonTable = () => {
     isLoadingSections,
     isErrorSections,
   } = useQuery({
-    queryKey: ["sections", auth.token],
+    queryKey: ["sections", authData?.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/sections/all`,
@@ -57,6 +58,7 @@ const AdminLessonTable = () => {
 
       return response.data;
     },
+    enabled: !!authData,
   });
 
   const {
@@ -64,17 +66,18 @@ const AdminLessonTable = () => {
     isLoadingCards,
     isErrorCards,
   } = useQuery({
-    queryKey: ["cards", auth.token],
+    queryKey: ["cards", authData?.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/cards/all`,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData?.token}` },
         },
       );
 
       return response.data;
     },
+    enabled: !!authData,
   });
 
   const handleEdit = (card) => {
@@ -88,7 +91,7 @@ const AdminLessonTable = () => {
         `${process.env.REACT_APP_API_BASE}/api/lessons/update/${editedLesson._id}`,
         editedLesson,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
     },
@@ -111,7 +114,7 @@ const AdminLessonTable = () => {
       await axios.delete(
         `${process.env.REACT_APP_API_BASE}/api/lessons/delete/${lessonId}`,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
     },
@@ -135,7 +138,7 @@ const AdminLessonTable = () => {
         `${process.env.REACT_APP_API_BASE}/api/lessons/create`,
         lesson,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
     },

--- a/src/Routes/AdminSectionTable.js
+++ b/src/Routes/AdminSectionTable.js
@@ -20,7 +20,7 @@ import NewSectionForm from "../Components/NewSectionForm";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 const AdminSectionTable = () => {
-  const { auth } = useAuth();
+  const { authData } = useAuth();
   const { showSnackbar } = useSnackbar();
   const [editingSectionId, setEditingSectionId] = useState(null);
   const [editedSection, setEditedSection] = useState({});
@@ -31,7 +31,7 @@ const AdminSectionTable = () => {
     isLoadingLessons,
     isErrorLessons,
   } = useQuery({
-    queryKey: ["lessons", auth.token],
+    queryKey: ["lessons", authData?.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/lessons/all`,
@@ -39,6 +39,7 @@ const AdminSectionTable = () => {
 
       return response.data;
     },
+    enabled: !!authData,
   });
 
   const {
@@ -46,7 +47,7 @@ const AdminSectionTable = () => {
     isLoadingSections,
     isErrorSections,
   } = useQuery({
-    queryKey: ["sections", auth.token],
+    queryKey: ["sections", authData?.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/sections/all`,
@@ -54,6 +55,7 @@ const AdminSectionTable = () => {
 
       return response.data;
     },
+    enabled: !!authData,
   });
 
   const handleEdit = (section) => {
@@ -67,7 +69,7 @@ const AdminSectionTable = () => {
         `${process.env.REACT_APP_API_BASE}/api/sections/update/${editingSectionId}`,
         editedSection,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
     },
@@ -90,7 +92,7 @@ const AdminSectionTable = () => {
       await axios.delete(
         `${process.env.REACT_APP_API_BASE}/api/sections/delete/${sectionId}`,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
     },
@@ -114,7 +116,7 @@ const AdminSectionTable = () => {
         `${process.env.REACT_APP_API_BASE}/api/sections/create`,
         section,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
     },

--- a/src/Routes/AdminUserTable.js
+++ b/src/Routes/AdminUserTable.js
@@ -18,7 +18,7 @@ import {
 } from "@mui/material";
 
 const AdminUserTable = () => {
-  const { auth } = useAuth();
+  const { authData } = useAuth();
   const { showSnackbar } = useSnackbar();
   const [editingUserId, setEditingUserId] = useState(null);
   const [editedUser, setEditedUser] = useState({});
@@ -29,16 +29,17 @@ const AdminUserTable = () => {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ["users", auth.token],
+    queryKey: ["users", authData?.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/users/admin/all`,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
       return response.data;
     },
+    enabled: !!authData,
   });
 
   useEffect(() => {
@@ -67,13 +68,13 @@ const AdminUserTable = () => {
         `${process.env.REACT_APP_API_BASE}/api/users/update/${userId}`,
         editedUser,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
     },
     onSuccess: () => {
       showSnackbar("User updated successfully", "success");
-      queryClient.invalidateQueries(["users", auth.token]);
+      queryClient.invalidateQueries(["users", authData.token]);
     },
     onError: () => {
       showSnackbar("Failed to update user", "error");
@@ -90,13 +91,13 @@ const AdminUserTable = () => {
       await axios.delete(
         `${process.env.REACT_APP_API_BASE}/api/users/delete/${userId}`,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
     },
     onSuccess: () => {
       showSnackbar("User deleted successfully", "success");
-      queryClient.invalidateQueries(["users", auth.token]);
+      queryClient.invalidateQueries(["users", authData.token]);
     },
     onError: () => {
       showSnackbar("Failed to delete user", "error");

--- a/src/Routes/FlashcardLesson.js
+++ b/src/Routes/FlashcardLesson.js
@@ -9,7 +9,7 @@ import FlashcardsList from "../Components/FlashcardList";
 
 const FlashcardLesson = () => {
   const { lessonId } = useParams();
-  const { auth } = useAuth();
+  const { authData } = useAuth();
   const { showSnackbar } = useSnackbar();
 
   const {
@@ -17,12 +17,12 @@ const FlashcardLesson = () => {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ["lesson", lessonId, auth.token],
+    queryKey: ["lesson", lessonId, authData.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/lessons/${lessonId}`,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
       return response.data;
@@ -30,6 +30,7 @@ const FlashcardLesson = () => {
     onError: () => {
       showSnackbar("Failed to fetch lesson", "error");
     },
+    enabled: !!authData,
   });
 
   if (isLoading) {

--- a/src/Routes/FlashcardLesson.js
+++ b/src/Routes/FlashcardLesson.js
@@ -17,7 +17,7 @@ const FlashcardLesson = () => {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ["lesson", lessonId, authData.token],
+    queryKey: ["lesson", lessonId, authData?.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/lessons/${lessonId}`,
@@ -62,7 +62,7 @@ const FlashcardLesson = () => {
       }}
     >
       <Typography variant="h4" gutterBottom>
-        {lesson.title}
+        {lesson && lesson.title}
       </Typography>
       <FlashcardsList lessonId={lessonId} />
     </Box>

--- a/src/Routes/GrammarLesson.jsx
+++ b/src/Routes/GrammarLesson.jsx
@@ -10,7 +10,7 @@ import { useTheme } from "@mui/material/styles";
 
 const GrammarLesson = () => {
   const { lessonId } = useParams();
-  const { auth } = useAuth();
+  const { authData } = useAuth();
   const { showSnackbar } = useSnackbar();
   const theme = useTheme();
 
@@ -19,12 +19,12 @@ const GrammarLesson = () => {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ["lesson", lessonId, auth.token],
+    queryKey: ["lesson", lessonId, authData?.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/lessons/${lessonId}`,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
       return response.data;
@@ -32,6 +32,7 @@ const GrammarLesson = () => {
     onError: () => {
       showSnackbar("Failed to fetch lesson", "error");
     },
+    enabled: !!authData,
   });
 
   if (isLoading) {

--- a/src/Routes/LessonList.js
+++ b/src/Routes/LessonList.js
@@ -8,7 +8,7 @@ import { useAuth } from "../Contexts/AuthContext";
 import { useSnackbar } from "../Contexts/SnackbarContext";
 
 const LessonList = () => {
-  const { auth } = useAuth();
+  const { authData } = useAuth();
   const { showSnackbar } = useSnackbar();
   const theme = useTheme();
   const categoryColors = {
@@ -27,12 +27,12 @@ const LessonList = () => {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ["lessons", auth.token],
+    queryKey: ["lessons", authData?.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/lessons/all`,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
       return response.data;
@@ -40,6 +40,7 @@ const LessonList = () => {
     onError: () => {
       showSnackbar("Failed to fetch lessons", "error");
     },
+    enabled: !!authData,
   });
 
   if (isLoading) {
@@ -83,30 +84,31 @@ const LessonList = () => {
       <Typography variant="h4" gutterBottom>
         Lessons
       </Typography>
-      {lessons.map((lesson) => (
-        <Box
-          key={lesson.id}
-          sx={{
-            p: 1.5,
-            mb: 2,
-            width: "70%",
-            display: "flex",
-            justifyContent: "space-between",
-            border: `2px solid ${theme.palette.primary.contrastText}`,
-            borderRadius: 2,
-          }}
-        >
-          <Typography variant="h6">{lesson.title}</Typography>
-          <Button
-            variant="contained"
-            color={categoryColors[lesson.category]}
-            component={Link}
-            to={`${categoryRoutes[lesson.category]}/${lesson._id}`}
+      {lessons &&
+        lessons.map((lesson) => (
+          <Box
+            key={lesson.id}
+            sx={{
+              p: 1.5,
+              mb: 2,
+              width: "70%",
+              display: "flex",
+              justifyContent: "space-between",
+              border: `2px solid ${theme.palette.primary.contrastText}`,
+              borderRadius: 2,
+            }}
           >
-            {lesson.category}
-          </Button>
-        </Box>
-      ))}
+            <Typography variant="h6">{lesson.title}</Typography>
+            <Button
+              variant="contained"
+              color={categoryColors[lesson.category]}
+              component={Link}
+              to={`${categoryRoutes[lesson.category]}/${lesson._id}`}
+            >
+              {lesson.category}
+            </Button>
+          </Box>
+        ))}
     </Box>
   );
 };

--- a/src/Routes/PracticeLesson.jsx
+++ b/src/Routes/PracticeLesson.jsx
@@ -10,7 +10,7 @@ import "./PracticeLesson.css";
 
 const PracticeLesson = () => {
   const { lessonId } = useParams();
-  const { auth } = useAuth();
+  const { authData } = useAuth();
   const { showSnackbar } = useSnackbar();
   const [currentSentence, setCurrentSentence] = useState(0);
   const [animationClass, setAnimationClass] = useState("slide-in");
@@ -21,12 +21,12 @@ const PracticeLesson = () => {
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ["lesson", lessonId, auth.token],
+    queryKey: ["lesson", lessonId, authData?.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/lessons/${lessonId}`,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
       return response.data;
@@ -34,6 +34,7 @@ const PracticeLesson = () => {
     onError: () => {
       showSnackbar("Failed to fetch lesson", "error");
     },
+    enabled: !!authData,
   });
 
   // Event handler for switching to the next sentence

--- a/src/Routes/Profile.js
+++ b/src/Routes/Profile.js
@@ -8,7 +8,7 @@ import { useSnackbar } from "../Contexts/SnackbarContext";
 import { useAuth } from "../Contexts/AuthContext";
 
 function Profile() {
-  const { auth, logout } = useAuth();
+  const { auth, authData, logout } = useAuth();
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -19,12 +19,12 @@ function Profile() {
     isError,
     isLoading,
   } = useQuery({
-    queryKey: ["user", auth.token],
+    queryKey: ["user", authData?.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/users/`,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
       return response.data;
@@ -53,7 +53,7 @@ function Profile() {
       await axios.delete(
         `${process.env.REACT_APP_API_BASE}/api/users/delete/${user._id}`,
         {
-          headers: { Authorization: `Bearer ${auth.token}` },
+          headers: { Authorization: `Bearer ${authData.token}` },
         },
       );
     },
@@ -121,7 +121,7 @@ function Profile() {
     );
   }
 
-  if (!auth.isLoggedIn) {
+  if (!authData.isLoggedIn) {
     return (
       <Typography variant="h6" textAlign="center">
         Please log in to view your profile.

--- a/src/Routes/Profile.js
+++ b/src/Routes/Profile.js
@@ -8,7 +8,7 @@ import { useSnackbar } from "../Contexts/SnackbarContext";
 import { useAuth } from "../Contexts/AuthContext";
 
 function Profile() {
-  const { auth, authData, logout } = useAuth();
+  const { authData, logout } = useAuth();
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -59,7 +59,7 @@ function Profile() {
     },
     onSuccess: () => {
       showSnackbar("Profile deleted successfully", "success");
-      queryClient.invalidateQueries(["user", auth.token]);
+      queryClient.invalidateQueries(["user", authData.token]);
       logout(() => navigate("/home"));
     },
     onError: (error) => {

--- a/src/Routes/UpdateProfile.js
+++ b/src/Routes/UpdateProfile.js
@@ -14,7 +14,7 @@ import { useSnackbar } from "../Contexts/SnackbarContext";
 import { useAuth } from "../Contexts/AuthContext";
 
 function UpdateProfile() {
-  const { auth, logout } = useAuth();
+  const { authData, logout } = useAuth();
   const [username, setUsername] = useState("");
   const navigate = useNavigate();
   const [password, setPassword] = useState("");
@@ -26,13 +26,13 @@ function UpdateProfile() {
     isError,
     isLoading,
   } = useQuery({
-    queryKey: ["user", auth.token],
+    queryKey: ["user", authData?.token],
     queryFn: async () => {
       const response = await axios.get(
         `${process.env.REACT_APP_API_BASE}/api/users`,
         {
           headers: {
-            Authorization: `Bearer ${auth.token}`,
+            Authorization: `Bearer ${authData.token}`,
           },
         },
       );
@@ -48,6 +48,7 @@ function UpdateProfile() {
         showSnackbar(`Error: ${error.response.data.detail}`, "error");
       }
     },
+    enabled: !!authData,
   });
 
   const updateMutation = useMutation({
@@ -57,7 +58,7 @@ function UpdateProfile() {
         updatedUser,
         {
           headers: {
-            Authorization: `Bearer ${auth.token}`,
+            Authorization: `Bearer ${authData.token}`,
           },
         },
       );
@@ -127,7 +128,7 @@ function UpdateProfile() {
     updateMutation.mutate(updatedUser);
   };
 
-  if (!auth.isLoggedIn) {
+  if (!authData.isLoggedIn) {
     return (
       <Typography variant="h6" textAlign="center">
         Please log in to update your profile.


### PR DESCRIPTION
# Related to #24 

### Brief Description
<!-- Describe the purpose of this pull request -->
In this pull request, I changed the AuthContext away from useEffect() and useState(), and toward React-Query. 
### Changes
<!-- Describe the changes made in this pull request -->
- The AuthContext now stores auth data in an `authData` variable, populated by a query. This helped with making the data persist better when refreshing the page. 
- All of the other pages now use `authData` instead of the old `auth` variable