### PR TITLE
Use new fsrs implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^5.16.7",
         "@tanstack/react-query": "^5.51.24",
         "axios": "^1.7.3",
+        "dayjs": "^1.11.13",
         "mui-markdown": "^1.2.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -6622,6 +6623,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -21831,6 +21838,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@mui/material": "^5.16.7",
     "@tanstack/react-query": "^5.51.24",
     "axios": "^1.7.3",
+    "dayjs": "^1.11.13",
     "mui-markdown": "^1.2.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/Components/FlashcardList.js
+++ b/src/Components/FlashcardList.js
@@ -13,6 +13,8 @@ import { useAuth } from "../Contexts/AuthContext";
 import { useSnackbar } from "../Contexts/SnackbarContext";
 import Flashcard from "./Flashcard";
 import { useTheme } from "@mui/material/styles";
+import useLessonReview from "../hooks/useLessonReview";
+import ReviewModal from "../Components/ReviewModal";
 
 const FlashcardList = ({ lessonId }) => {
   const { authData } = useAuth();
@@ -21,7 +23,14 @@ const FlashcardList = ({ lessonId }) => {
   const [showTranslation, setShowTranslation] = useState(false);
   const [isEnglishToJapanese, setIsEnglishToJapanese] = useState(true);
   const [hasFinished, setHasFinished] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
   const theme = useTheme();
+
+  const { handlePerformanceReview } = useLessonReview(
+    lessonId,
+    modalOpen,
+    setModalOpen,
+  );
 
   const {
     data: flashcards = [],
@@ -82,6 +91,7 @@ const FlashcardList = ({ lessonId }) => {
         showSnackbar("You have reached the end of the lesson!", "success");
         setHasFinished(true);
         setCurrentCardIndex(0);
+        setModalOpen(true);
       } else {
         setCurrentCardIndex((prevIndex) => prevIndex + 1);
       }
@@ -155,6 +165,11 @@ const FlashcardList = ({ lessonId }) => {
           </Stack>
         </>
       )}
+      <ReviewModal
+        open={modalOpen}
+        setOpen={setModalOpen}
+        handlePerformanceReview={handlePerformanceReview}
+      />
     </Box>
   );
 };

--- a/src/Components/ReviewModal.js
+++ b/src/Components/ReviewModal.js
@@ -1,0 +1,73 @@
+import React from "react";
+import { Box, Button, IconButton, Modal, Typography } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+
+function ReviewModal({ open, setOpen, handlePerformanceReview }) {
+  return (
+    <Modal open={open}>
+      <Box
+        sx={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          width: 500,
+          bgcolor: "background.paper",
+          border: "2px solid #000",
+          boxShadow: 24,
+          p: 4,
+          borderRadius: 2,
+        }}
+      >
+        <IconButton
+          sx={{ position: "absolute", top: 8, right: 8 }}
+          onClick={() => setOpen(false)}
+        >
+          <CloseIcon />
+        </IconButton>
+        <Typography variant="h6" component="h2" textAlign={"center"}>
+          Lesson Complete!
+        </Typography>
+        <Typography sx={{ mt: 2 }}>
+          How would you rate your performance?
+        </Typography>
+        <Box sx={{ mt: 2, display: "flex", justifyContent: "space-between" }}>
+          <Button
+            variant="contained"
+            onClick={() => {
+              handlePerformanceReview(0.1);
+            }}
+          >
+            Again (1)
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => {
+              handlePerformanceReview(0.45);
+            }}
+          >
+            Hard (2)
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => {
+              handlePerformanceReview(0.7);
+            }}
+          >
+            Good (3)
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => {
+              handlePerformanceReview(0.9);
+            }}
+          >
+            Easy (4)
+          </Button>
+        </Box>
+      </Box>
+    </Modal>
+  );
+}
+
+export default ReviewModal;

--- a/src/Components/TranslationQuestion.jsx
+++ b/src/Components/TranslationQuestion.jsx
@@ -6,6 +6,7 @@ import { useTheme } from "@mui/material/styles";
 const TranslationQuestion = ({ sentence, onNext }) => {
   const [userAnswer, setUserAnswer] = useState("");
   const [isCorrect, setIsCorrect] = useState();
+  const [randomAnswer, setRandomAnswer] = useState(0); // Random possible answer for when the user is incorrect
   const { showSnackbar } = useSnackbar();
   const theme = useTheme();
   const inputRef = useRef(null);
@@ -56,6 +57,10 @@ const TranslationQuestion = ({ sentence, onNext }) => {
       showSnackbar("Correct!", "success");
       setTimeout(onNext, 500);
     } else {
+      // Select a random answer to show the user if they are incorrect
+      setRandomAnswer(
+        Math.floor(Math.random() * sentence.possible_answers.length),
+      );
       setIsCorrect(false);
       showSnackbar("Incorrect", "error");
     }
@@ -100,6 +105,12 @@ const TranslationQuestion = ({ sentence, onNext }) => {
       <Button onClick={checkAnswer} variant="contained" sx={{ mt: 2 }}>
         Submit
       </Button>
+      {isCorrect !== null && !isCorrect && (
+        <Typography variant="body1" color="error" sx={{ mt: 2 }}>
+          Incorrect! One correct answer is: "
+          {sentence.possible_answers[randomAnswer]}"
+        </Typography>
+      )}
     </Box>
   );
 };

--- a/src/Routes/GrammarLesson.jsx
+++ b/src/Routes/GrammarLesson.jsx
@@ -1,18 +1,28 @@
-import React from "react";
+import React, { useState } from "react";
 import { MuiMarkdown, getOverrides } from "mui-markdown";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
-import { Box, Skeleton, Typography } from "@mui/material";
+import { Box, Button, Icon, Skeleton, Typography } from "@mui/material";
+import { Done } from "@mui/icons-material";
 import { useParams } from "react-router-dom";
 import { useAuth } from "../Contexts/AuthContext";
 import { useSnackbar } from "../Contexts/SnackbarContext";
 import { useTheme } from "@mui/material/styles";
+import useLessonReview from "../hooks/useLessonReview";
+import ReviewModal from "../Components/ReviewModal";
 
 const GrammarLesson = () => {
   const { lessonId } = useParams();
   const { authData } = useAuth();
   const { showSnackbar } = useSnackbar();
+  const [modalOpen, setModalOpen] = useState(false);
   const theme = useTheme();
+
+  const { handlePerformanceReview } = useLessonReview(
+    lessonId,
+    modalOpen,
+    setModalOpen,
+  );
 
   const {
     data: lesson,
@@ -92,6 +102,21 @@ const GrammarLesson = () => {
       >
         {lesson.content}
       </MuiMarkdown>
+      <Button
+        sx={{ mt: 2, display: "flex", alignItems: "center" }}
+        variant={"contained"}
+        onClick={() => setModalOpen(true)}
+      >
+        Finished{" "}
+        <Icon sx={{ ml: 1, mb: 0.5, display: "flex", alignItems: "center" }}>
+          <Done />
+        </Icon>
+      </Button>
+      <ReviewModal
+        open={modalOpen}
+        setOpen={setModalOpen}
+        handlePerformanceReview={handlePerformanceReview}
+      />
     </Box>
   );
 };

--- a/src/Routes/LessonList.js
+++ b/src/Routes/LessonList.js
@@ -43,6 +43,29 @@ const LessonList = () => {
     enabled: !!authData,
   });
 
+  // Fetch user's lesson reviews
+  const {
+    data: reviews,
+    isLoading: reviewsLoading,
+    isError: reviewsError,
+  } = useQuery({
+    queryKey: ["reviews", authData?.token],
+    queryFn: async () => {
+      const response = await axios.get(
+        `${process.env.REACT_APP_API_BASE}/api/lessons/reviews`,
+        {
+          headers: { Authorization: `Bearer ${authData.token}` },
+        },
+      );
+
+      return response.data;
+    },
+    onError: () => {
+      showSnackbar("Failed to fetch reviews", "error");
+    },
+    enabled: !!authData,
+  });
+
   if (isLoading) {
     return (
       <Box

--- a/src/Routes/LessonList.js
+++ b/src/Routes/LessonList.js
@@ -6,6 +6,7 @@ import { Box, Button, Skeleton, Typography, useTheme } from "@mui/material";
 import { Link } from "react-router-dom";
 import { useAuth } from "../Contexts/AuthContext";
 import { useSnackbar } from "../Contexts/SnackbarContext";
+import dayjs from "dayjs";
 
 const LessonList = () => {
   const { authData } = useAuth();
@@ -95,6 +96,19 @@ const LessonList = () => {
     return <Typography>Error loading lessons.</Typography>;
   }
 
+  // Helper function to get review information for a specific lesson
+  const getReviewForLesson = (lessonId) => {
+    const review = reviews?.find((review) => review.lesson_id === lessonId);
+    if (review) {
+      const daysLeft = dayjs(review.next_review).diff(dayjs(), "day");
+      return {
+        daysLeft: daysLeft,
+        isOverdue: daysLeft < 0,
+      };
+    }
+    return null;
+  };
+
   return (
     <Box
       sx={{
@@ -108,30 +122,49 @@ const LessonList = () => {
         Lessons
       </Typography>
       {lessons &&
-        lessons.map((lesson) => (
-          <Box
-            key={lesson.id}
-            sx={{
-              p: 1.5,
-              mb: 2,
-              width: "70%",
-              display: "flex",
-              justifyContent: "space-between",
-              border: `2px solid ${theme.palette.primary.contrastText}`,
-              borderRadius: 2,
-            }}
-          >
-            <Typography variant="h6">{lesson.title}</Typography>
-            <Button
-              variant="contained"
-              color={categoryColors[lesson.category]}
-              component={Link}
-              to={`${categoryRoutes[lesson.category]}/${lesson._id}`}
+        lessons.map((lesson) => {
+          const review = getReviewForLesson(lesson._id);
+          return (
+            <Box
+              key={lesson.id}
+              sx={{
+                p: 1.5,
+                mb: 2,
+                width: "70%",
+                display: "flex",
+                justifyContent: "space-between",
+                border: `2px solid ${theme.palette.primary.contrastText}`,
+                borderRadius: 2,
+              }}
             >
-              {lesson.category}
-            </Button>
-          </Box>
-        ))}
+              <Box>
+                <Typography variant="h6">{lesson.title}</Typography>
+                {review && (
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      color: review.isOverdue
+                        ? theme.palette.error.main
+                        : theme.palette.text.secondary,
+                    }}
+                  >
+                    {review.isOverdue
+                      ? `Overdue by ${Math.abs(review.daysLeft)} days`
+                      : `Next review in ${review.daysLeft} days`}
+                  </Typography>
+                )}
+              </Box>
+              <Button
+                variant="contained"
+                color={categoryColors[lesson.category]}
+                component={Link}
+                to={`${categoryRoutes[lesson.category]}/${lesson._id}`}
+              >
+                {lesson.category}
+              </Button>
+            </Box>
+          );
+        })}
     </Box>
   );
 };

--- a/src/Routes/PracticeLesson.jsx
+++ b/src/Routes/PracticeLesson.jsx
@@ -117,7 +117,7 @@ const PracticeLesson = () => {
               top: "50%",
               left: "50%",
               transform: "translate(-50%, -50%)",
-              width: 400,
+              width: 500,
               bgcolor: "background.paper",
               border: "2px solid #000",
               boxShadow: 24,
@@ -131,7 +131,7 @@ const PracticeLesson = () => {
             >
               <CloseIcon />
             </IconButton>
-            <Typography variant="h6" component="h2">
+            <Typography variant="h6" component="h2" textAlign={"center"}>
               Lesson Complete!
             </Typography>
             <Typography sx={{ mt: 2 }}>
@@ -146,7 +146,7 @@ const PracticeLesson = () => {
                   handlePerformanceReview(0.1);
                 }}
               >
-                Again
+                Again (1)
               </Button>
               <Button
                 variant="contained"
@@ -154,7 +154,7 @@ const PracticeLesson = () => {
                   handlePerformanceReview(0.45);
                 }}
               >
-                Hard
+                Hard (2)
               </Button>
               <Button
                 variant="contained"
@@ -162,7 +162,7 @@ const PracticeLesson = () => {
                   handlePerformanceReview(0.7);
                 }}
               >
-                Good
+                Good (3)
               </Button>
               <Button
                 variant="contained"
@@ -170,7 +170,7 @@ const PracticeLesson = () => {
                   handlePerformanceReview(0.9);
                 }}
               >
-                Easy
+                Easy (4)
               </Button>
             </Box>
           </Box>

--- a/src/Routes/PracticeLesson.jsx
+++ b/src/Routes/PracticeLesson.jsx
@@ -64,11 +64,6 @@ const PracticeLesson = () => {
     }, 400);
   };
 
-  const handlePerformanceReview = (rating) => {
-    setOverallPerformance(rating);
-    handleLessonComplete.mutate();
-  };
-
   const handleLessonComplete = useMutation({
     mutationFn: async () => {
       await axios.post(
@@ -88,6 +83,11 @@ const PracticeLesson = () => {
       setModalOpen(false);
       navigate("/lessons");
     },
+  });
+
+  const handlePerformanceReview = useCallback((rating) => {
+    setOverallPerformance(rating);
+    handleLessonComplete.mutate();
   });
 
   // Hotkeys for reviewing the lesson

--- a/src/Routes/PracticeLesson.jsx
+++ b/src/Routes/PracticeLesson.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import axios from "axios";
 import {
@@ -15,6 +15,7 @@ import { useAuth } from "../Contexts/AuthContext";
 import { useSnackbar } from "../Contexts/SnackbarContext";
 import TranslationQuestion from "../Components/TranslationQuestion";
 import "./PracticeLesson.css";
+import { useNavigate } from "react-router-dom";
 
 const PracticeLesson = () => {
   const { lessonId } = useParams();
@@ -25,6 +26,7 @@ const PracticeLesson = () => {
   const [modalOpen, setModalOpen] = useState(false);
   const [animationClass, setAnimationClass] = useState("slide-in");
   const nodeRef = useRef(null);
+  const navigate = useNavigate();
 
   const {
     data: lesson,
@@ -84,6 +86,7 @@ const PracticeLesson = () => {
     onSuccess: () => {
       showSnackbar("Lesson marked as complete", "success");
       setModalOpen(false);
+      navigate("/lessons");
     },
   });
 

--- a/src/Routes/PracticeLesson.jsx
+++ b/src/Routes/PracticeLesson.jsx
@@ -1,21 +1,14 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import React, { useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
-import {
-  Box,
-  Modal,
-  Skeleton,
-  Typography,
-  Button,
-  IconButton,
-} from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
+import { Box, Skeleton, Typography } from "@mui/material";
 import { useParams } from "react-router-dom";
 import { useAuth } from "../Contexts/AuthContext";
 import { useSnackbar } from "../Contexts/SnackbarContext";
 import TranslationQuestion from "../Components/TranslationQuestion";
 import "./PracticeLesson.css";
 import useLessonReview from "../hooks/useLessonReview";
+import ReviewModal from "../Components/ReviewModal";
 
 const PracticeLesson = () => {
   const { lessonId } = useParams();
@@ -110,72 +103,12 @@ const PracticeLesson = () => {
           sentence={lesson.sentences[currentSentence]}
           onNext={handleNext}
         />
-        <Modal open={modalOpen}>
-          <Box
-            sx={{
-              position: "absolute",
-              top: "50%",
-              left: "50%",
-              transform: "translate(-50%, -50%)",
-              width: 500,
-              bgcolor: "background.paper",
-              border: "2px solid #000",
-              boxShadow: 24,
-              p: 4,
-              borderRadius: 2,
-            }}
-          >
-            <IconButton
-              sx={{ position: "absolute", top: 8, right: 8 }}
-              onClick={() => setModalOpen(false)}
-            >
-              <CloseIcon />
-            </IconButton>
-            <Typography variant="h6" component="h2" textAlign={"center"}>
-              Lesson Complete!
-            </Typography>
-            <Typography sx={{ mt: 2 }}>
-              How would you rate your performance?
-            </Typography>
-            <Box
-              sx={{ mt: 2, display: "flex", justifyContent: "space-between" }}
-            >
-              <Button
-                variant="contained"
-                onClick={() => {
-                  handlePerformanceReview(0.1);
-                }}
-              >
-                Again (1)
-              </Button>
-              <Button
-                variant="contained"
-                onClick={() => {
-                  handlePerformanceReview(0.45);
-                }}
-              >
-                Hard (2)
-              </Button>
-              <Button
-                variant="contained"
-                onClick={() => {
-                  handlePerformanceReview(0.7);
-                }}
-              >
-                Good (3)
-              </Button>
-              <Button
-                variant="contained"
-                onClick={() => {
-                  handlePerformanceReview(0.9);
-                }}
-              >
-                Easy (4)
-              </Button>
-            </Box>
-          </Box>
-        </Modal>
       </Box>
+      <ReviewModal
+        open={modalOpen}
+        setOpen={setModalOpen}
+        handlePerformanceReview={handlePerformanceReview}
+      />
     </Box>
   );
 };

--- a/src/Routes/PracticeLesson.jsx
+++ b/src/Routes/PracticeLesson.jsx
@@ -85,10 +85,13 @@ const PracticeLesson = () => {
     },
   });
 
-  const handlePerformanceReview = useCallback((rating) => {
-    setOverallPerformance(rating);
-    handleLessonComplete.mutate();
-  });
+  const handlePerformanceReview = useCallback(
+    (rating) => {
+      setOverallPerformance(rating);
+      handleLessonComplete.mutate();
+    },
+    [handleLessonComplete, setOverallPerformance],
+  );
 
   // Hotkeys for reviewing the lesson
   useEffect(() => {

--- a/src/Routes/PracticeLesson.jsx
+++ b/src/Routes/PracticeLesson.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { useQuery, useMutation } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import {
   Box,
@@ -27,6 +27,7 @@ const PracticeLesson = () => {
   const [animationClass, setAnimationClass] = useState("slide-in");
   const nodeRef = useRef(null);
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const {
     data: lesson,
@@ -81,6 +82,7 @@ const PracticeLesson = () => {
     onSuccess: () => {
       showSnackbar("Lesson marked as complete", "success");
       setModalOpen(false);
+      queryClient.invalidateQueries("lessons");
       navigate("/lessons");
     },
   });

--- a/src/Routes/PracticeLesson.jsx
+++ b/src/Routes/PracticeLesson.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import axios from "axios";
 import {
@@ -86,6 +86,35 @@ const PracticeLesson = () => {
       setModalOpen(false);
     },
   });
+
+  // Hotkeys for reviewing the lesson
+  useEffect(() => {
+    const handleKeyPress = (event) => {
+      if (modalOpen) {
+        switch (event.key) {
+          case "1":
+            handlePerformanceReview(0.1);
+            break;
+          case "2":
+            handlePerformanceReview(0.45);
+            break;
+          case "3":
+            handlePerformanceReview(0.7);
+            break;
+          case "4":
+            handlePerformanceReview(0.9);
+            break;
+          default:
+            break;
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyPress);
+    return () => {
+      window.removeEventListener("keydown", handleKeyPress);
+    };
+  }, [modalOpen, handleLessonComplete, handlePerformanceReview]);
 
   if (isLoading) {
     return (

--- a/src/hooks/useLessonReview.js
+++ b/src/hooks/useLessonReview.js
@@ -1,0 +1,77 @@
+// src/hooks/useLessonComplete.js
+import { useCallback, useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { useNavigate } from "react-router-dom";
+import { useSnackbar } from "../Contexts/SnackbarContext";
+import { useAuth } from "../Contexts/AuthContext";
+
+const useLessonReview = (lessonId, modalOpen, setModalOpen) => {
+  const { authData } = useAuth();
+  const { showSnackbar } = useSnackbar();
+  const [overallPerformance, setOverallPerformance] = useState(0);
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const handleLessonComplete = useMutation({
+    mutationFn: async () => {
+      await axios.post(
+        `${process.env.REACT_APP_API_BASE}/api/lessons/review`,
+        { lesson_id: lessonId, overall_performance: overallPerformance },
+        {
+          headers: { Authorization: `Bearer ${authData.token}` },
+        },
+      );
+    },
+    onError: () => {
+      showSnackbar("Failed to mark lesson as complete", "error");
+      setModalOpen(false);
+    },
+    onSuccess: () => {
+      showSnackbar("Lesson marked as complete", "success");
+      setModalOpen(false);
+      queryClient.invalidateQueries("lessons");
+      navigate("/lessons");
+    },
+  });
+
+  const handlePerformanceReview = useCallback(
+    (rating) => {
+      setOverallPerformance(rating);
+      handleLessonComplete.mutate();
+    },
+    [handleLessonComplete, setOverallPerformance],
+  );
+
+  useEffect(() => {
+    const handleKeyPress = (event) => {
+      if (modalOpen) {
+        switch (event.key) {
+          case "1":
+            handlePerformanceReview(0.1);
+            break;
+          case "2":
+            handlePerformanceReview(0.45);
+            break;
+          case "3":
+            handlePerformanceReview(0.7);
+            break;
+          case "4":
+            handlePerformanceReview(0.9);
+            break;
+          default:
+            break;
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyPress);
+    return () => {
+      window.removeEventListener("keydown", handleKeyPress);
+    };
+  }, [modalOpen, handlePerformanceReview]);
+
+  return { handlePerformanceReview };
+};
+
+export default useLessonReview;


### PR DESCRIPTION
### Brief Description
<!-- Describe the purpose of this pull request -->
In this pull request, I updated the lessons to use the FSRS scheduler from the backend to show review due dates for lessons
### Changes
<!-- Describe the changes made in this pull request -->
- There is now a Review Modal that will show when a user finishes a lesson
  - In it, the user can select one of four options (shown below) to review the lesson, where the backend will assign a next_review date
  - There are also hotkeys (numbers 1-4) that will review the lesson
- There is now a button at the bottom of grammar pages that finishes the lesson
- After the final sentence in a practice lesson, the lesson will be finished
- After the final card in a flashcard lesson, the lesson will be finished
- On the lesson list page, if a lesson has been completed before, there will be text showing how many days are left until the lesson should be reviewed
  - If a lesson is overdue, the text will be red to draw attention to it

### Screenshots (if applicable)
<!-- Add screenshots to help showcase your changes -->
The updated lesson list 
![image](https://github.com/user-attachments/assets/13597d69-1388-415c-9dd5-a445c1d24431)

Review Modal
![image](https://github.com/user-attachments/assets/ca24d3f9-f684-44ae-a596-7bbdaa59499a)
