### PR TITLE
Group lessons by section

### DIFF
--- a/src/Routes/LessonList.js
+++ b/src/Routes/LessonList.js
@@ -1,7 +1,14 @@
 import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
-import { Box, Button, Skeleton, Typography, useTheme } from "@mui/material";
+import {
+  Box,
+  Button,
+  Skeleton,
+  Typography,
+  useTheme,
+  Divider,
+} from "@mui/material";
 import { Link } from "react-router-dom";
 import { useAuth } from "../Contexts/AuthContext";
 import { useSnackbar } from "../Contexts/SnackbarContext";
@@ -164,6 +171,17 @@ const LessonList = () => {
           <Typography variant="h5" gutterBottom>
             {sectionName}
           </Typography>
+          <Divider
+            sx={{
+              width: "33%",
+              mb: 2,
+              borderColor:
+                theme.palette.mode === "dark"
+                  ? "primary.dark"
+                  : "primary.light",
+              borderWidth: "1px",
+            }}
+          />
           {groupedLessons[sectionName].length > 0 ? (
             groupedLessons[sectionName].map((lesson) => {
               const review = getReviewForLesson(lesson._id);
@@ -175,7 +193,7 @@ const LessonList = () => {
                     mb: 2,
                     display: "flex",
                     justifyContent: "space-between",
-                    border: `2px solid ${theme.palette.primary.contrastText}`,
+                    border: `2px solid ${theme.palette.secondary.contrastText}`,
                     borderRadius: 2,
                   }}
                 >

--- a/src/Routes/LessonList.js
+++ b/src/Routes/LessonList.js
@@ -44,7 +44,28 @@ const LessonList = () => {
     enabled: !!authData,
   });
 
-  // Fetch user's lesson reviews
+  const {
+    data: sections,
+    isLoading: sectionsLoading,
+    isError: sectionsError,
+  } = useQuery({
+    queryKey: ["sections", authData?.token],
+    queryFn: async () => {
+      const response = await axios.get(
+        `${process.env.REACT_APP_API_BASE}/api/sections/all`,
+        {
+          headers: { Authorization: `Bearer ${authData.token}` },
+        },
+      );
+
+      return response.data;
+    },
+    onError: () => {
+      showSnackbar("Failed to fetch sections", "error");
+    },
+    enabled: !!authData && !!lessons,
+  });
+
   const {
     data: reviews,
     isLoading: reviewsLoading,
@@ -67,7 +88,7 @@ const LessonList = () => {
     enabled: !!authData,
   });
 
-  if (isLoading) {
+  if (isLoading || sectionsLoading || reviewsLoading) {
     return (
       <Box
         sx={{
@@ -92,7 +113,7 @@ const LessonList = () => {
     );
   }
 
-  if (isError) {
+  if (isError || sectionsError || reviewsError) {
     return <Typography>Error loading lessons.</Typography>;
   }
 

--- a/src/Routes/LessonList.js
+++ b/src/Routes/LessonList.js
@@ -226,6 +226,9 @@ const LessonList = () => {
                   <Button
                     variant="contained"
                     color={categoryColors[lesson.category]}
+                    sx={{
+                      color: theme.palette.mode === "dark" ? "white" : "black",
+                    }}
                     component={Link}
                     to={`${categoryRoutes[lesson.category]}/${lesson._id}`}
                   >

--- a/src/Routes/LessonList.js
+++ b/src/Routes/LessonList.js
@@ -193,8 +193,17 @@ const LessonList = () => {
                     mb: 2,
                     display: "flex",
                     justifyContent: "space-between",
-                    border: `2px solid ${theme.palette.secondary.contrastText}`,
+                    border: `2px solid ${theme.palette.mode === "dark" ? theme.palette.primary.contrastText : theme.palette.secondary.contrastText}`,
                     borderRadius: 2,
+                    boxShadow: `0px 0px 5px 0px ${
+                      theme.palette.mode === "dark"
+                        ? theme.palette.primary.contrastText
+                        : theme.palette.secondary.contrastText
+                    }`,
+                    transition: "transform 0.3s ease",
+                    "&:hover": {
+                      transform: "scale(1.05)",
+                    },
                   }}
                 >
                   <Box>

--- a/src/Routes/LessonList.js
+++ b/src/Routes/LessonList.js
@@ -130,6 +130,24 @@ const LessonList = () => {
     return null;
   };
 
+  // Group together the lessons
+  let groupedLessons = {};
+  if (sections) {
+    groupedLessons = sections.reduce((acc, section) => {
+      acc[section.name] = lessons.filter(
+        (lesson) => lesson.section_id === section._id,
+      );
+      return acc;
+    }, {});
+
+    // Handle lessons without sections in an "Extras" segment
+    groupedLessons["Extras"] = lessons.filter(
+      (lesson) =>
+        !lesson.section_id ||
+        !sections.some((section) => section._id === lesson.section_id),
+    );
+  }
+
   return (
     <Box
       sx={{

--- a/src/Routes/LessonList.js
+++ b/src/Routes/LessonList.js
@@ -1,4 +1,3 @@
-// src/Routes/LessonList.js
 import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";

--- a/src/Routes/LessonList.js
+++ b/src/Routes/LessonList.js
@@ -160,50 +160,59 @@ const LessonList = () => {
       <Typography variant="h4" gutterBottom>
         Lessons
       </Typography>
-      {lessons &&
-        lessons.map((lesson) => {
-          const review = getReviewForLesson(lesson._id);
-          return (
-            <Box
-              key={lesson.id}
-              sx={{
-                p: 1.5,
-                mb: 2,
-                width: "70%",
-                display: "flex",
-                justifyContent: "space-between",
-                border: `2px solid ${theme.palette.primary.contrastText}`,
-                borderRadius: 2,
-              }}
-            >
-              <Box>
-                <Typography variant="h6">{lesson.title}</Typography>
-                {review && (
-                  <Typography
-                    variant="body2"
-                    sx={{
-                      color: review.isOverdue
-                        ? theme.palette.error.main
-                        : theme.palette.text.secondary,
-                    }}
+      {Object.keys(groupedLessons).map((sectionName) => (
+        <Box key={sectionName} sx={{ width: "70%", mb: 4 }}>
+          <Typography variant="h5" gutterBottom>
+            {sectionName}
+          </Typography>
+          {groupedLessons[sectionName].length > 0 ? (
+            groupedLessons[sectionName].map((lesson) => {
+              const review = getReviewForLesson(lesson._id);
+              return (
+                <Box
+                  key={lesson._id}
+                  sx={{
+                    p: 1.5,
+                    mb: 2,
+                    display: "flex",
+                    justifyContent: "space-between",
+                    border: `2px solid ${theme.palette.primary.contrastText}`,
+                    borderRadius: 2,
+                  }}
+                >
+                  <Box>
+                    <Typography variant="h6">{lesson.title}</Typography>
+                    {review && (
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          color: review.isOverdue
+                            ? theme.palette.error.main
+                            : theme.palette.text.secondary,
+                        }}
+                      >
+                        {review.isOverdue
+                          ? `Overdue by ${Math.abs(review.daysLeft)} days`
+                          : `Next review in ${review.daysLeft} days`}
+                      </Typography>
+                    )}
+                  </Box>
+                  <Button
+                    variant="contained"
+                    color={categoryColors[lesson.category]}
+                    component={Link}
+                    to={`${categoryRoutes[lesson.category]}/${lesson._id}`}
                   >
-                    {review.isOverdue
-                      ? `Overdue by ${Math.abs(review.daysLeft)} days`
-                      : `Next review in ${review.daysLeft} days`}
-                  </Typography>
-                )}
-              </Box>
-              <Button
-                variant="contained"
-                color={categoryColors[lesson.category]}
-                component={Link}
-                to={`${categoryRoutes[lesson.category]}/${lesson._id}`}
-              >
-                {lesson.category}
-              </Button>
-            </Box>
-          );
-        })}
+                    {lesson.category}
+                  </Button>
+                </Box>
+              );
+            })
+          ) : (
+            <Typography>No lessons available for this section.</Typography>
+          )}
+        </Box>
+      ))}
     </Box>
   );
 };


### PR DESCRIPTION
# Closes #54 

### Brief Description
<!-- Describe the purpose of this pull request -->
In this pull request, I split up the lessons in the lesson list page into groups based on their sections. I also made some style changes to the list to make it more appealing (hopefully). 

### Changes
<!-- Describe the changes made in this pull request -->
- A request is made to the API to fetch all of the sections in the database, and all lessons are mapped to their corresponding sections.
  - If a lesson isn't assigned to a section, it will be put into the final "Extras" section (only cosmetically)
- The border around the lessons will change color based on if you're in light mode or dark mode
- There's now a box shadow around the lessons that will also change color based on light/dark mode. 
- Button text color in the lesson list will be white in dark mode and black in light mode, regardless of their type

### Screenshots (if applicable)
<!-- Add screenshots to help showcase your changes -->
Dark mode
![image](https://github.com/user-attachments/assets/e05d00e7-bec2-42f6-8d7e-e822009b46b8)

Light mode
![image](https://github.com/user-attachments/assets/1558663b-6381-4e13-9a75-bd0998e5b412)
