### PR TITLE
Wrapped the fetchAuthState query in a try-catch block to handle 401 e…

### DIFF
--- a/src/Contexts/AuthContext.js
+++ b/src/Contexts/AuthContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useState } from "react";
+import React, { createContext, useCallback, useContext } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import { useSnackbar } from "./SnackbarContext";
@@ -18,22 +18,27 @@ export const AuthProvider = ({ children }) => {
     if (!token) {
       return { isLoggedIn: false, isAdmin: false, token: "", username: "" };
     }
-    const response = await axios.get(
-      `${process.env.REACT_APP_API_BASE}/api/auth/check-admin`,
-      {
-        headers: { Authorization: `Bearer ${token}` },
-      },
-    );
+    try {
+      const response = await axios.get(
+        `${process.env.REACT_APP_API_BASE}/api/auth/check-admin`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
 
-    if (response.status >= 400) {
+      if (response.status >= 401) {
+        return { isLoggedIn: false, isAdmin: false, token: "", username: "" };
+      }
+
+      return {
+        token,
+        isLoggedIn: true,
+        isAdmin: response.data.isAdmin,
+        username: localStorage.getItem("username"),
+      };
+    } catch (error) {
       return { isLoggedIn: false, isAdmin: false, token: "", username: "" };
     }
-    return {
-      token,
-      isLoggedIn: true,
-      isAdmin: response.data.isAdmin,
-      username: localStorage.getItem("username"),
-    };
   };
 
   const { data: authData, isLoading: authIsLoading } = useQuery({

--- a/src/Contexts/AuthContext.js
+++ b/src/Contexts/AuthContext.js
@@ -37,6 +37,8 @@ export const AuthProvider = ({ children }) => {
         username: localStorage.getItem("username"),
       };
     } catch (error) {
+      localStorage.removeItem("token");
+      localStorage.removeItem("username");
       return { isLoggedIn: false, isAdmin: false, token: "", username: "" };
     }
   };


### PR DESCRIPTION
…rrors from the backend

### Brief Description
<!-- Describe the purpose of this pull request -->
In this pull request, I fixed a bug where the app would crash if the user provided an invalid/stale JWT
### Changes
<!-- Describe the changes made in this pull request -->
- The query for fetching the auth state is now wrapped in a try-catch block
- If there is an error, the authData will be set to empty defaults
- If there is an error, the localstorage information for the token and username are also cleared