### PR TITLE
Investigate smoother theme switching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,6 @@ import {
   ThemeProvider,
   useColorScheme,
 } from "@mui/material";
-
 import { useRoutes } from "react-router";
 import NavBar from "./Components/NavBar";
 import { BrowserRouter } from "react-router-dom";
@@ -56,7 +55,6 @@ const palette: ColorSystemOptions = {
     },
   },
 };
-
 
 const theme = createTheme({
   colorSchemes: {

--- a/src/Components/NavBar.tsx
+++ b/src/Components/NavBar.tsx
@@ -82,9 +82,9 @@ function NavBar() {
       if (!pages.find((page) => page.name === "User Table")) {
         let mobileExtraPages: Page[] = isMobile
           ? [
-            { name: "Profile", endpoint: "/profile" },
-            { name: "Logout", action: handleLogout },
-          ]
+              { name: "Profile", endpoint: "/profile" },
+              { name: "Logout", action: handleLogout },
+            ]
           : [];
 
         setPages((prevPages) => {
@@ -212,9 +212,7 @@ function NavBar() {
             <LightMode />
           </Icon>
           <Switch
-            onChange={() =>
-              setMode(mode === "light" ? "dark" : "light")
-            }
+            onChange={() => setMode(mode === "light" ? "dark" : "light")}
             color={"default"}
             checked={mode === "dark"}
             sx={{ mt: 0.7 }}


### PR DESCRIPTION
# Closes #X (where X is the issue number, if applicable)

## Brief Description

<!-- Describe the purpose of this pull request -->

In this pull request, I finally changed from using the two separate themes to using 1 unified one with the colorSchemes API

## Changes

<!-- Describe the changes made in this pull request -->

- Instead of two theme objects, there's 1 that provides both dark and light mode versions
  - This fixed a bug where forms and text entry elements would rerender and reset when changing the theme
  - Additionally the themes now use `colorScheme` setup instead of just the raw `palette` one
- The theme defaults to light mode if the user hasn't been to the site before or if their browser storage is empty
- The theme uses the `noSsr` flag to prevent the "dark mode flicker"
