### PR TITLE
Fixed the Review.next_date attribute name

### DIFF
--- a/src/Routes/LessonList.tsx
+++ b/src/Routes/LessonList.tsx
@@ -108,11 +108,11 @@ const LessonList = () => {
 
   // Helper function to get review information for a specific lesson
   const getReviewForLesson = (lessonId: string): ReviewStats | null => {
-    const review = reviews?.find(
+    const review: Review = reviews?.find(
       (review: Review) => review.lesson_id === lessonId,
     );
     if (review) {
-      const daysLeft = dayjs(review.next_review_date).diff(dayjs(), "day");
+      const daysLeft = dayjs(review.next_review).diff(dayjs(), "day");
       return {
         daysLeft: daysLeft,
         isOverdue: daysLeft < 0,

--- a/src/types/lessons.ts
+++ b/src/types/lessons.ts
@@ -40,5 +40,5 @@ export interface Review {
   lesson_id: string;
   user_id: string;
   card_object: Card;
-  next_review_date: Date;
+  next_review: Date;
 }


### PR DESCRIPTION
## Brief Description

<!-- Describe the purpose of this pull request -->

In this pull request, I fixed a bug where the days remaining before the next scheduled lesson review was always 0

## Changes

<!-- Describe the changes made in this pull request -->

- The Review interface uses the right variable name now