### PR TITLE
Add tabbed lesson table

### DIFF
--- a/src/Components/admin/LessonTable.tsx
+++ b/src/Components/admin/LessonTable.tsx
@@ -21,11 +21,11 @@ import axios from "axios";
 import { Card } from "@/types/cards";
 
 const categoryColumnVisibility: Record<string, GridColumnVisibilityModel> = {
-  All: { "_id": false },
-  Grammar: { "_id": false, "sentences": false, "card_ids": false },
-  Flashcards: { "_id": false, "sentences": false, "content": false },
-  Practice: { "_id": false, "card_ids": false, "content": false }
-}
+  All: { _id: false },
+  Grammar: { _id: false, sentences: false, card_ids: false },
+  Flashcards: { _id: false, sentences: false, content: false },
+  Practice: { _id: false, card_ids: false, content: false },
+};
 
 export const LessonTable = ({
   cards,
@@ -41,7 +41,10 @@ export const LessonTable = ({
   const { showSnackbar } = useSnackbar();
   const [selectedCategory, setSelectedCategory] = useState<string>("All");
   const categories = ["All", "Grammar", "Flashcards", "Practice"];
-  const filteredLessons = lessons.filter((lesson) => lesson.category?.toLowerCase() === selectedCategory.toLowerCase());
+  const filteredLessons = lessons.filter(
+    (lesson) =>
+      lesson.category?.toLowerCase() === selectedCategory.toLowerCase(),
+  );
   const queryClient = useQueryClient();
 
   const updateMutation = useMutation({
@@ -249,19 +252,17 @@ export const LessonTable = ({
     },
   ];
 
-  const [columnVisibilityModel, setColumnVisibilityModel] = useState(categoryColumnVisibility[selectedCategory])
+  const [columnVisibilityModel, setColumnVisibilityModel] = useState(
+    categoryColumnVisibility[selectedCategory],
+  );
   const handleTabChange = (_: React.SyntheticEvent, newCategory: string) => {
     setSelectedCategory(newCategory);
-    setColumnVisibilityModel((categoryColumnVisibility[newCategory]));
-  }
+    setColumnVisibilityModel(categoryColumnVisibility[newCategory]);
+  };
 
   return (
     <Box sx={{ height: 600, width: "90%", mx: "auto" }}>
-      <Tabs
-        value={selectedCategory}
-        onChange={handleTabChange}
-        sx={{ mb: 2 }}
-      >
+      <Tabs value={selectedCategory} onChange={handleTabChange} sx={{ mb: 2 }}>
         {categories.map((category) => (
           <Tab key={category} label={category} value={category} />
         ))}


### PR DESCRIPTION
## Brief Description

<!-- Describe the purpose of this pull request -->

In this pull request, I updated the lessons table to have a tabbed layout that filters lessons by category

## Changes

<!-- Describe the changes made in this pull request -->

- There are now four tabs available
  1. "All"
  2. "Grammar"
  3. "Flashcard"
  4. "Practice"
- The fields not relevant to each lesson type are hidden when filtered
- Some style updates were made (width and flex)

## Screenshots (if applicable)

<!-- Add screenshots to help showcase your changes -->
<img width="1545" height="943" alt="LinguaTile Admin Lessons Tabbed" src="https://github.com/user-attachments/assets/1874cf1d-e6e5-472c-847a-f11e72f9ab7f" />
<img width="1545" height="943" alt="LinguaTile Admin Lessons Grammar" src="https://github.com/user-attachments/assets/4036b609-e211-4807-83f1-bd9ced2105c8" />
