### PR TITLE
Improve other lesson UIs

### DIFF
--- a/src/Components/LessonListItem.tsx
+++ b/src/Components/LessonListItem.tsx
@@ -56,10 +56,11 @@ export const LessonListItem = ({
         height: "100%",
         border: `2px solid ${theme.palette.mode === "dark" ? grey["400"] : grey["200"]}`,
         borderRadius: 2,
-        boxShadow: `0px 0px 5px 0px ${theme.palette.mode === "dark"
-          ? theme.palette.primary.contrastText
-          : theme.palette.secondary.contrastText
-          }`,
+        boxShadow: `0px 0px 5px 0px ${
+          theme.palette.mode === "dark"
+            ? theme.palette.primary.contrastText
+            : theme.palette.secondary.contrastText
+        }`,
         transition: "transform 0.3s ease",
         "&:hover": {
           transform: "scale(1.05)",

--- a/src/Components/ReviewModal.tsx
+++ b/src/Components/ReviewModal.tsx
@@ -110,10 +110,11 @@ function ReviewModal({
               theme.palette.mode === "dark"
                 ? "0 8px 32px 0 rgba(0, 0, 0, 0.5)"
                 : "0 8px 32px 0 rgba(31, 38, 135, 0.15)",
-            border: `1px solid ${theme.palette.mode === "dark"
-              ? "rgba(255, 255, 255, 0.1)"
-              : "rgba(255, 255, 255, 0.4)"
-              }`,
+            border: `1px solid ${
+              theme.palette.mode === "dark"
+                ? "rgba(255, 255, 255, 0.1)"
+                : "rgba(255, 255, 255, 0.4)"
+            }`,
             p: 4,
             outline: "none",
           }}
@@ -128,7 +129,11 @@ function ReviewModal({
             variant="h4"
             component="h2"
             textAlign={"center"}
-            sx={{ fontWeight: "bold", mb: 1, color: theme.palette.text.primary }}
+            sx={{
+              fontWeight: "bold",
+              mb: 1,
+              color: theme.palette.text.primary,
+            }}
           >
             Lesson Complete!
           </Typography>
@@ -192,7 +197,5 @@ function ReviewModal({
     </Modal>
   );
 }
-
-
 
 export default ReviewModal;

--- a/src/Components/TranslationQuestion.tsx
+++ b/src/Components/TranslationQuestion.tsx
@@ -102,10 +102,11 @@ const TranslationQuestion = ({
           theme.palette.mode === "dark"
             ? "0 8px 32px 0 rgba(0, 0, 0, 0.5)"
             : "0 8px 32px 0 rgba(31, 38, 135, 0.15)",
-        border: `1px solid ${theme.palette.mode === "dark"
-          ? "rgba(255, 255, 255, 0.1)"
-          : "rgba(255, 255, 255, 0.4)"
-          }`,
+        border: `1px solid ${
+          theme.palette.mode === "dark"
+            ? "rgba(255, 255, 255, 0.1)"
+            : "rgba(255, 255, 255, 0.4)"
+        }`,
         transition: "transform 0.3s ease, box-shadow 0.3s ease",
         "&:hover": {
           transform: isMobile ? "none" : "translateY(-5px)",
@@ -116,11 +117,24 @@ const TranslationQuestion = ({
         },
       }}
     >
-      <Box sx={{ p: isMobile ? 3 : 5, display: "flex", flexDirection: "column", alignItems: "center" }}>
+      <Box
+        sx={{
+          p: isMobile ? 3 : 5,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+        }}
+      >
         <Typography
           variant="h6"
           color="text.secondary"
-          sx={{ mb: 2, fontWeight: 500, textTransform: "uppercase", letterSpacing: 1, fontSize: "0.8rem" }}
+          sx={{
+            mb: 2,
+            fontWeight: 500,
+            textTransform: "uppercase",
+            letterSpacing: 1,
+            fontSize: "0.8rem",
+          }}
         >
           Translate this sentence
         </Typography>
@@ -152,7 +166,10 @@ const TranslationQuestion = ({
             mb: 3,
             "& .MuiOutlinedInput-root": {
               borderRadius: 3,
-              backgroundColor: theme.palette.mode === "dark" ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.02)",
+              backgroundColor:
+                theme.palette.mode === "dark"
+                  ? "rgba(255,255,255,0.05)"
+                  : "rgba(0,0,0,0.02)",
               "& fieldset": {
                 borderColor: theme.palette.divider,
               },
@@ -172,7 +189,13 @@ const TranslationQuestion = ({
           variant="contained"
           size="large"
           fullWidth
-          color={isCorrect === true ? "success" : isCorrect === false ? "error" : "primary"}
+          color={
+            isCorrect === true
+              ? "success"
+              : isCorrect === false
+                ? "error"
+                : "primary"
+          }
           sx={{
             borderRadius: 3,
             py: 1.5,
@@ -182,7 +205,11 @@ const TranslationQuestion = ({
             transition: "all 0.3s ease",
           }}
         >
-          {isCorrect === true ? "Correct!" : isCorrect === false ? "Try Again" : "Check Answer"}
+          {isCorrect === true
+            ? "Correct!"
+            : isCorrect === false
+              ? "Try Again"
+              : "Check Answer"}
         </Button>
 
         {isCorrect !== null && !isCorrect && (
@@ -192,7 +219,10 @@ const TranslationQuestion = ({
               p: 2,
               width: "100%",
               borderRadius: 2,
-              backgroundColor: theme.palette.mode === "dark" ? "rgba(211, 47, 47, 0.1)" : "rgba(211, 47, 47, 0.05)",
+              backgroundColor:
+                theme.palette.mode === "dark"
+                  ? "rgba(211, 47, 47, 0.1)"
+                  : "rgba(211, 47, 47, 0.05)",
               border: `1px solid ${theme.palette.error.main}`,
               display: "flex",
               flexDirection: "column",
@@ -200,7 +230,12 @@ const TranslationQuestion = ({
               animation: "fadeIn 0.3s ease-in",
             }}
           >
-            <Typography variant="subtitle1" color="error" fontWeight="bold" gutterBottom>
+            <Typography
+              variant="subtitle1"
+              color="error"
+              fontWeight="bold"
+              gutterBottom
+            >
               Incorrect
             </Typography>
             <Typography variant="body1" color="text.primary" align="center">

--- a/src/Routes/GrammarLesson.tsx
+++ b/src/Routes/GrammarLesson.tsx
@@ -83,10 +83,11 @@ const GrammarLesson = () => {
           theme.palette.mode === "dark"
             ? "0 8px 32px 0 rgba(0, 0, 0, 0.5)"
             : "0 8px 32px 0 rgba(31, 38, 135, 0.15)",
-        border: `1px solid ${theme.palette.mode === "dark"
-          ? "rgba(255, 255, 255, 0.1)"
-          : "rgba(255, 255, 255, 0.4)"
-          }`,
+        border: `1px solid ${
+          theme.palette.mode === "dark"
+            ? "rgba(255, 255, 255, 0.1)"
+            : "rgba(255, 255, 255, 0.4)"
+        }`,
         transition: "transform 0.3s ease, box-shadow 0.3s ease",
         "&:hover": {
           boxShadow:
@@ -96,7 +97,14 @@ const GrammarLesson = () => {
         },
       }}
     >
-      <Box sx={{ p: isMobile ? 3 : 5, display: "flex", flexDirection: "column", alignItems: "center" }}>
+      <Box
+        sx={{
+          p: isMobile ? 3 : 5,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+        }}
+      >
         <MuiMarkdown
           hideLineNumbers
           overrides={getMarkdownOverrides(isMobile, theme)}
@@ -107,7 +115,9 @@ const GrammarLesson = () => {
         <Tooltip
           title={
             !authData?.isLoggedIn ? (
-              <Typography>You must be logged in to finish the lesson.</Typography>
+              <Typography>
+                You must be logged in to finish the lesson.
+              </Typography>
             ) : (
               <Typography>Finish Lesson</Typography>
             )
@@ -139,9 +149,7 @@ const GrammarLesson = () => {
               }}
             >
               Finish Lesson
-              <Icon
-                sx={{ ml: 1, display: "flex", alignItems: "center" }}
-              >
+              <Icon sx={{ ml: 1, display: "flex", alignItems: "center" }}>
                 <Done />
               </Icon>
             </Button>
@@ -229,9 +237,10 @@ const getMarkdownOverrides = (isMobile: boolean, theme: Theme) => ({
         maxWidth: "100%",
         height: "auto",
         borderRadius: "8px",
-        boxShadow: theme.palette.mode === "dark"
-          ? "0 4px 12px rgba(0,0,0,0.5)"
-          : "0 4px 12px rgba(0,0,0,0.15)",
+        boxShadow:
+          theme.palette.mode === "dark"
+            ? "0 4px 12px rgba(0,0,0,0.5)"
+            : "0 4px 12px rgba(0,0,0,0.15)",
         marginTop: "1rem",
         marginBottom: "1rem",
         display: "block",

--- a/src/Routes/PracticeLesson.css
+++ b/src/Routes/PracticeLesson.css
@@ -23,15 +23,14 @@
 }
 
 .slide-in {
-  animation: slideIn 0.4s cubic-bezier(0.4, 0.0, 0.2, 1) forwards;
+  animation: slideIn 0.4s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
 .slide-out {
-  animation: slideOut 0.3s cubic-bezier(0.4, 0.0, 0.2, 1) forwards;
+  animation: slideOut 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
 @keyframes shake {
-
   0%,
   100% {
     transform: translateX(0);
@@ -54,5 +53,5 @@
 }
 
 .shake {
-  animation: shake 0.4s cubic-bezier(.36, .07, .19, .97) both;
+  animation: shake 0.4s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
 }

--- a/src/Routes/PracticeLesson.tsx
+++ b/src/Routes/PracticeLesson.tsx
@@ -1,11 +1,7 @@
 import { useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
-import {
-  Box,
-  Skeleton,
-  Typography,
-} from "@mui/material";
+import { Box, Skeleton, Typography } from "@mui/material";
 import { useParams } from "react-router-dom";
 import { useAuth } from "../Contexts/AuthContext";
 import { useSnackbar } from "../Contexts/SnackbarContext";


### PR DESCRIPTION
## Brief Description

<!-- Describe the purpose of this pull request -->

In this pull request, I updated the grammar and practice lesson styles to flashcard styles, and the review modal styles.

## Changes

<!-- Describe the changes made in this pull request -->

- The grammar lesson markdown elements have styles
- The practice lesson has some more feedback to show when users are right or wrong
  - On a correct answer, a snackbar shows up, and the border turns green
  - On a wrong answer, the box shakes and the border turns red
- The review modal has updated styles

## Screenshots (if applicable)

<!-- Add screenshots to help showcase your changes -->
<img width="1545" height="943" alt="LinguaTile Practice Lesson" src="https://github.com/user-attachments/assets/992b9121-9072-479e-955a-e90c4bb318e6" />
<img width="1545" height="943" alt="LinguaTile Review Modal" src="https://github.com/user-attachments/assets/de5c2567-0338-49b2-8307-ffecf60bc591" />
