### PR TITLE
Add unified admin dashboard

### DIFF
--- a/src/Components/admin/LessonEditModal.tsx
+++ b/src/Components/admin/LessonEditModal.tsx
@@ -1,0 +1,217 @@
+import { useState, useEffect } from "react";
+import {
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Add, Close, Delete } from "@mui/icons-material";
+import MarkdownPreviewer from "@/Components/MarkdownPreviewer";
+import { Lesson, Sentence } from "@/types/lessons";
+
+interface LessonEditModalProps {
+  open: boolean;
+  onClose: () => void;
+  lesson: Lesson | null;
+  onSave: (lessonId: string, updates: Partial<Lesson>) => void;
+  isSaving: boolean;
+}
+
+export const LessonEditModal = ({
+  open,
+  onClose,
+  lesson,
+  onSave,
+  isSaving,
+}: LessonEditModalProps) => {
+  // Local state for editing
+  const [content, setContent] = useState("");
+  const [sentences, setSentences] = useState<Sentence[]>([]);
+
+  // Reset state when lesson changes
+  useEffect(() => {
+    if (lesson) {
+      setContent(lesson.content || "");
+      setSentences(lesson.sentences || []);
+    }
+  }, [lesson]);
+
+  const handleSave = () => {
+    if (!lesson) return;
+
+    if (lesson.category === "grammar") {
+      onSave(lesson._id, { content });
+    } else if (lesson.category === "practice") {
+      // Auto-generate words from full_sentence for each sentence
+      const sentencesWithWords = sentences.map((s) => ({
+        ...s,
+        words: s.full_sentence.split(/\s+/).filter(Boolean),
+      }));
+      onSave(lesson._id, { sentences: sentencesWithWords });
+    }
+  };
+
+  // Sentence editing handlers
+  const handleSentenceChange = (index: number, value: string) => {
+    const updated = [...sentences];
+    updated[index] = { ...updated[index], full_sentence: value };
+    setSentences(updated);
+  };
+
+  const handleAnswerChange = (sentenceIndex: number, answerIndex: number, value: string) => {
+    const updated = [...sentences];
+    updated[sentenceIndex].possible_answers[answerIndex] = value;
+    setSentences(updated);
+  };
+
+  const addSentence = () => {
+    setSentences([...sentences, { full_sentence: "", possible_answers: [""], words: [] }]);
+  };
+
+  const removeSentence = (index: number) => {
+    setSentences(sentences.filter((_, i) => i !== index));
+  };
+
+  const addAnswer = (sentenceIndex: number) => {
+    const updated = [...sentences];
+    updated[sentenceIndex].possible_answers.push("");
+    setSentences(updated);
+  };
+
+  const removeAnswer = (sentenceIndex: number, answerIndex: number) => {
+    const updated = [...sentences];
+    updated[sentenceIndex].possible_answers = updated[sentenceIndex].possible_answers.filter(
+      (_, i) => i !== answerIndex
+    );
+    setSentences(updated);
+  };
+
+  if (!lesson) return null;
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle>
+        Edit: {lesson.title}
+        <IconButton
+          onClick={onClose}
+          sx={{ position: "absolute", right: 8, top: 8 }}
+        >
+          <Close />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        {lesson.category === "grammar" && (
+          <Box>
+            <Typography variant="subtitle1" gutterBottom>
+              Markdown Content
+            </Typography>
+            <MarkdownPreviewer
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+            />
+          </Box>
+        )}
+
+        {lesson.category === "practice" && (
+          <Box>
+            <Typography variant="subtitle1" gutterBottom>
+              Practice Sentences ({sentences.length})
+            </Typography>
+
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+              {sentences.map((sentence, sIndex) => (
+                <Card key={sIndex} variant="outlined">
+                  <CardContent>
+                    <TextField
+                      label="Japanese Sentence"
+                      value={sentence.full_sentence}
+                      onChange={(e) => handleSentenceChange(sIndex, e.target.value)}
+                      fullWidth
+                      sx={{ mb: 2 }}
+                    />
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                      Possible Answers:
+                    </Typography>
+                    {sentence.possible_answers.map((answer, aIndex) => (
+                      <Box key={aIndex} sx={{ display: "flex", gap: 1, mb: 1 }}>
+                        <TextField
+                          size="small"
+                          label={`Answer ${aIndex + 1}`}
+                          value={answer}
+                          onChange={(e) => handleAnswerChange(sIndex, aIndex, e.target.value)}
+                          sx={{ flex: 1 }}
+                        />
+                        <IconButton
+                          size="small"
+                          onClick={() => removeAnswer(sIndex, aIndex)}
+                          disabled={sentence.possible_answers.length <= 1}
+                        >
+                          <Close fontSize="small" />
+                        </IconButton>
+                      </Box>
+                    ))}
+                    <Button
+                      size="small"
+                      startIcon={<Add />}
+                      onClick={() => addAnswer(sIndex)}
+                    >
+                      Add Answer
+                    </Button>
+                  </CardContent>
+                  <CardActions>
+                    <Button
+                      size="small"
+                      color="error"
+                      startIcon={<Delete />}
+                      onClick={() => removeSentence(sIndex)}
+                    >
+                      Remove Sentence
+                    </Button>
+                  </CardActions>
+                </Card>
+              ))}
+            </Box>
+
+            <Button
+              variant="outlined"
+              startIcon={<Add />}
+              onClick={addSentence}
+              sx={{ mt: 2 }}
+            >
+              Add Sentence
+            </Button>
+          </Box>
+        )}
+
+        {lesson.category === "flashcards" && (
+          <Typography color="text.secondary">
+            Use the inline card creation in the dashboard to manage flashcards.
+          </Typography>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={isSaving || lesson.category === "flashcards"}
+        >
+          {isSaving ? "Saving..." : "Save Changes"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default LessonEditModal;
+

--- a/src/Components/admin/LessonEditModal.tsx
+++ b/src/Components/admin/LessonEditModal.tsx
@@ -86,15 +86,18 @@ export const LessonEditModal = ({
       };
       onCreate(newLesson);
     } else if (lesson) {
+      const updates: Partial<Lesson> = {
+        section_id: sectionId || undefined,
+      };
       if (lesson.category === "grammar") {
-        onSave(lesson._id, { content });
+        updates.content = content;
       } else if (lesson.category === "practice") {
-        const sentencesWithWords = sentences.map((s) => ({
+        updates.sentences = sentences.map((s) => ({
           ...s,
           words: s.full_sentence.split(/\s+/).filter(Boolean),
         }));
-        onSave(lesson._id, { sentences: sentencesWithWords });
       }
+      onSave(lesson._id, updates);
     }
   };
 
@@ -136,7 +139,7 @@ export const LessonEditModal = ({
   const currentCategory = isCreateMode ? category : lesson?.category;
   const canSave = isCreateMode
     ? title.trim() !== ""
-    : currentCategory !== "flashcards";
+    : true; // All lesson types can save (at minimum for section changes)
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
@@ -151,7 +154,26 @@ export const LessonEditModal = ({
       </DialogTitle>
 
       <DialogContent dividers>
-        {/* Create mode: show title, category, section fields */}
+        {/* Section selector - shown in both modes */}
+        {sections.length > 0 && (
+          <Box sx={{ mb: 2 }}>
+            <FormControl fullWidth size="small">
+              <InputLabel>Section</InputLabel>
+              <Select
+                value={sectionId}
+                label="Section"
+                onChange={(e) => setSectionId(e.target.value)}
+              >
+                <MenuItem value="">None (Ungrouped)</MenuItem>
+                {sections.map((s) => (
+                  <MenuItem key={s._id} value={s._id}>{s.name}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+        )}
+
+        {/* Create mode: show title, category fields */}
         {isCreateMode && (
           <Box sx={{ mb: 3 }}>
             <Box sx={{ display: "flex", gap: 2, mb: 2 }}>
@@ -175,21 +197,6 @@ export const LessonEditModal = ({
                   <MenuItem value="practice">Practice</MenuItem>
                 </Select>
               </FormControl>
-              {sections.length > 0 && (
-                <FormControl sx={{ minWidth: 150 }}>
-                  <InputLabel>Section</InputLabel>
-                  <Select
-                    value={sectionId}
-                    label="Section"
-                    onChange={(e) => setSectionId(e.target.value)}
-                  >
-                    <MenuItem value="">None (Ungrouped)</MenuItem>
-                    {sections.map((s) => (
-                      <MenuItem key={s._id} value={s._id}>{s.name}</MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              )}
             </Box>
           </Box>
         )}
@@ -284,7 +291,7 @@ export const LessonEditModal = ({
           <Typography color="text.secondary">
             {isCreateMode
               ? "After creating this lesson, you can add cards using the inline card creator in the dashboard."
-              : "Use the inline card creation in the dashboard to manage flashcards."
+              : "You can change the section above. Cards are managed inline in the dashboard."
             }
           </Typography>
         )}

--- a/src/Components/admin/LessonEditModal.tsx
+++ b/src/Components/admin/LessonEditModal.tsx
@@ -28,6 +28,7 @@ interface LessonEditModalProps {
   lesson: Lesson | null; // null = create mode
   sections?: Section[];
   defaultSectionId?: string;
+  defaultOrderIndex?: number;
   onSave: (lessonId: string, updates: Partial<Lesson>) => void;
   onCreate?: (newLesson: NewLesson) => void;
   isSaving: boolean;
@@ -39,6 +40,7 @@ export const LessonEditModal = ({
   lesson,
   sections = [],
   defaultSectionId,
+  defaultOrderIndex,
   onSave,
   onCreate,
   isSaving,
@@ -76,6 +78,7 @@ export const LessonEditModal = ({
         title,
         category,
         section_id: sectionId || undefined,
+        order_index: defaultOrderIndex,
         content: category === "grammar" ? content : undefined,
         sentences: category === "practice"
           ? sentences.map((s) => ({

--- a/src/Components/admin/LessonEditModal.tsx
+++ b/src/Components/admin/LessonEditModal.tsx
@@ -80,12 +80,13 @@ export const LessonEditModal = ({
         section_id: sectionId || undefined,
         order_index: defaultOrderIndex,
         content: category === "grammar" ? content : undefined,
-        sentences: category === "practice"
-          ? sentences.map((s) => ({
-            ...s,
-            words: s.full_sentence.split(/\s+/).filter(Boolean),
-          }))
-          : undefined,
+        sentences:
+          category === "practice"
+            ? sentences.map((s) => ({
+                ...s,
+                words: s.full_sentence.split(/\s+/).filter(Boolean),
+              }))
+            : undefined,
       };
       onCreate(newLesson);
     } else if (lesson) {
@@ -111,14 +112,21 @@ export const LessonEditModal = ({
     setSentences(updated);
   };
 
-  const handleAnswerChange = (sentenceIndex: number, answerIndex: number, value: string) => {
+  const handleAnswerChange = (
+    sentenceIndex: number,
+    answerIndex: number,
+    value: string,
+  ) => {
     const updated = [...sentences];
     updated[sentenceIndex].possible_answers[answerIndex] = value;
     setSentences(updated);
   };
 
   const addSentence = () => {
-    setSentences([...sentences, { full_sentence: "", possible_answers: [""], words: [] }]);
+    setSentences([
+      ...sentences,
+      { full_sentence: "", possible_answers: [""], words: [] },
+    ]);
   };
 
   const removeSentence = (index: number) => {
@@ -133,16 +141,14 @@ export const LessonEditModal = ({
 
   const removeAnswer = (sentenceIndex: number, answerIndex: number) => {
     const updated = [...sentences];
-    updated[sentenceIndex].possible_answers = updated[sentenceIndex].possible_answers.filter(
-      (_, i) => i !== answerIndex
-    );
+    updated[sentenceIndex].possible_answers = updated[
+      sentenceIndex
+    ].possible_answers.filter((_, i) => i !== answerIndex);
     setSentences(updated);
   };
 
   const currentCategory = isCreateMode ? category : lesson?.category;
-  const canSave = isCreateMode
-    ? title.trim() !== ""
-    : true; // All lesson types can save (at minimum for section changes)
+  const canSave = isCreateMode ? title.trim() !== "" : true; // All lesson types can save (at minimum for section changes)
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
@@ -169,7 +175,9 @@ export const LessonEditModal = ({
               >
                 <MenuItem value="">None (Ungrouped)</MenuItem>
                 {sections.map((s) => (
-                  <MenuItem key={s._id} value={s._id}>{s.name}</MenuItem>
+                  <MenuItem key={s._id} value={s._id}>
+                    {s.name}
+                  </MenuItem>
                 ))}
               </Select>
             </FormControl>
@@ -193,7 +201,9 @@ export const LessonEditModal = ({
                 <Select
                   value={category}
                   label="Category"
-                  onChange={(e) => setCategory(e.target.value as LessonCategory)}
+                  onChange={(e) =>
+                    setCategory(e.target.value as LessonCategory)
+                  }
                 >
                   <MenuItem value="flashcards">Flashcards</MenuItem>
                   <MenuItem value="grammar">Grammar</MenuItem>
@@ -231,11 +241,17 @@ export const LessonEditModal = ({
                     <TextField
                       label="Japanese Sentence"
                       value={sentence.full_sentence}
-                      onChange={(e) => handleSentenceChange(sIndex, e.target.value)}
+                      onChange={(e) =>
+                        handleSentenceChange(sIndex, e.target.value)
+                      }
                       fullWidth
                       sx={{ mb: 2 }}
                     />
-                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{ mb: 1 }}
+                    >
                       Possible Answers:
                     </Typography>
                     {sentence.possible_answers.map((answer, aIndex) => (
@@ -244,7 +260,9 @@ export const LessonEditModal = ({
                           size="small"
                           label={`Answer ${aIndex + 1}`}
                           value={answer}
-                          onChange={(e) => handleAnswerChange(sIndex, aIndex, e.target.value)}
+                          onChange={(e) =>
+                            handleAnswerChange(sIndex, aIndex, e.target.value)
+                          }
                           sx={{ flex: 1 }}
                         />
                         <IconButton
@@ -294,8 +312,7 @@ export const LessonEditModal = ({
           <Typography color="text.secondary">
             {isCreateMode
               ? "After creating this lesson, you can add cards using the inline card creator in the dashboard."
-              : "You can change the section above. Cards are managed inline in the dashboard."
-            }
+              : "You can change the section above. Cards are managed inline in the dashboard."}
           </Typography>
         )}
       </DialogContent>
@@ -307,7 +324,11 @@ export const LessonEditModal = ({
           onClick={handleSave}
           disabled={isSaving || !canSave}
         >
-          {isSaving ? "Saving..." : isCreateMode ? "Create Lesson" : "Save Changes"}
+          {isSaving
+            ? "Saving..."
+            : isCreateMode
+              ? "Create Lesson"
+              : "Save Changes"}
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/Routes/AppRoutes.tsx
+++ b/src/Routes/AppRoutes.tsx
@@ -27,6 +27,7 @@ const AdminUserTable = lazy(() => import("./AdminUserTable"));
 const AdminLessonTable = lazy(() => import("./AdminLessonTable"));
 const AdminCardTable = lazy(() => import("./AdminCardTable"));
 const JourneyMap = lazy(() => import("./journey/JourneyMap"));
+const CurriculumDashboard = lazy(() => import("./CurriculumDashboard"));
 
 export const AppRoutes = () => {
   return useRoutes([
@@ -167,6 +168,16 @@ export const AppRoutes = () => {
             <ProtectedRoute isAdminPage={true}>
               <Suspense>
                 <AdminSectionTable />
+              </Suspense>
+            </ProtectedRoute>
+          ),
+        },
+        {
+          path: "/curriculum",
+          element: (
+            <ProtectedRoute isAdminPage={true}>
+              <Suspense fallback={<PageSkeleton />}>
+                <CurriculumDashboard />
               </Suspense>
             </ProtectedRoute>
           ),

--- a/src/Routes/CurriculumDashboard.tsx
+++ b/src/Routes/CurriculumDashboard.tsx
@@ -51,11 +51,16 @@ const CurriculumDashboard = () => {
 
   // State for lesson modal (create + edit)
   const [lessonModalOpen, setLessonModalOpen] = useState(false);
-  const [editingLessonContent, setEditingLessonContent] = useState<Lesson | null>(null);
-  const [defaultSectionForNewLesson, setDefaultSectionForNewLesson] = useState<string | undefined>(undefined);
+  const [editingLessonContent, setEditingLessonContent] =
+    useState<Lesson | null>(null);
+  const [defaultSectionForNewLesson, setDefaultSectionForNewLesson] = useState<
+    string | undefined
+  >(undefined);
 
-  const { data: sections = [], isLoading: isLoadingSections } = useSections(authData);
-  const { data: lessons = [], isLoading: isLoadingLessons } = useLessons(authData);
+  const { data: sections = [], isLoading: isLoadingSections } =
+    useSections(authData);
+  const { data: lessons = [], isLoading: isLoadingLessons } =
+    useLessons(authData);
   const { data: cards = [], isLoading: isLoadingCards } = useQuery({
     queryKey: ["cards", authData?.token],
     queryFn: async () => {
@@ -101,7 +106,15 @@ const CurriculumDashboard = () => {
   });
 
   const updateLessonMutation = useMutation({
-    mutationFn: async ({ id, title, order_index }: { id: string; title?: string; order_index?: number }) => {
+    mutationFn: async ({
+      id,
+      title,
+      order_index,
+    }: {
+      id: string;
+      title?: string;
+      order_index?: number;
+    }) => {
       const updates: { title?: string; order_index?: number } = {};
       if (title !== undefined) updates.title = title;
       if (order_index !== undefined) updates.order_index = order_index;
@@ -141,8 +154,18 @@ const CurriculumDashboard = () => {
   });
 
   const createCardMutation = useMutation({
-    mutationFn: async ({ front_text, back_text, lesson_id }: { front_text: string; back_text: string; lesson_id: string }) => {
-      await api.post("/api/cards/create-bulk", [{ front_text, back_text, lesson_ids: [lesson_id] }]);
+    mutationFn: async ({
+      front_text,
+      back_text,
+      lesson_id,
+    }: {
+      front_text: string;
+      back_text: string;
+      lesson_id: string;
+    }) => {
+      await api.post("/api/cards/create-bulk", [
+        { front_text, back_text, lesson_ids: [lesson_id] },
+      ]);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["cards"] });
@@ -152,7 +175,15 @@ const CurriculumDashboard = () => {
   });
 
   const updateCardMutation = useMutation({
-    mutationFn: async ({ id, front_text, back_text }: { id: string; front_text: string; back_text: string }) => {
+    mutationFn: async ({
+      id,
+      front_text,
+      back_text,
+    }: {
+      id: string;
+      front_text: string;
+      back_text: string;
+    }) => {
       await api.put(`/api/cards/update/${id}`, { front_text, back_text });
     },
     onSuccess: () => {
@@ -174,7 +205,13 @@ const CurriculumDashboard = () => {
   });
 
   const updateLessonContentMutation = useMutation({
-    mutationFn: async ({ id, updates }: { id: string; updates: Partial<Lesson> }) => {
+    mutationFn: async ({
+      id,
+      updates,
+    }: {
+      id: string;
+      updates: Partial<Lesson>;
+    }) => {
       await api.put(`/api/lessons/update/${id}`, updates);
     },
     onSuccess: () => {
@@ -200,10 +237,14 @@ const CurriculumDashboard = () => {
 
   const getCategoryColor = (category?: string) => {
     switch (category?.toLowerCase()) {
-      case "grammar": return "grammar";
-      case "flashcards": return "primary";
-      case "practice": return "secondary";
-      default: return "default";
+      case "grammar":
+        return "grammar";
+      case "flashcards":
+        return "primary";
+      case "practice":
+        return "secondary";
+      default:
+        return "default";
     }
   };
 
@@ -211,7 +252,10 @@ const CurriculumDashboard = () => {
     const sectionLessons = sectionId
       ? getLessonsForSection(sectionId)
       : getUngroupedLessons();
-    const maxOrder = sectionLessons.reduce((max, l) => Math.max(max, l.order_index ?? 0), 0);
+    const maxOrder = sectionLessons.reduce(
+      (max, l) => Math.max(max, l.order_index ?? 0),
+      0,
+    );
     return maxOrder + 1;
   };
 
@@ -268,7 +312,12 @@ const CurriculumDashboard = () => {
     setLessonModalOpen(true);
   };
 
-  if (isLoadingSections || isLoadingLessons || isLoadingCards || authIsLoading) {
+  if (
+    isLoadingSections ||
+    isLoadingLessons ||
+    isLoadingCards ||
+    authIsLoading
+  ) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", mt: 8 }}>
         <CircularProgress />
@@ -277,7 +326,7 @@ const CurriculumDashboard = () => {
   }
 
   const sortedSections = [...sections].sort(
-    (a, b) => (a.order_index ?? 0) - (b.order_index ?? 0)
+    (a, b) => (a.order_index ?? 0) - (b.order_index ?? 0),
   );
 
   return (
@@ -287,7 +336,9 @@ const CurriculumDashboard = () => {
       </Typography>
 
       {/* Add Section Form */}
-      <Paper sx={{ p: 2, mb: 3, display: "flex", gap: 2, alignItems: "center" }}>
+      <Paper
+        sx={{ p: 2, mb: 3, display: "flex", gap: 2, alignItems: "center" }}
+      >
         <TextField
           size="small"
           label="New Section Name"
@@ -300,7 +351,9 @@ const CurriculumDashboard = () => {
           variant="contained"
           startIcon={<Add />}
           onClick={handleAddSection}
-          disabled={!addingSectionName.trim() || createSectionMutation.isPending}
+          disabled={
+            !addingSectionName.trim() || createSectionMutation.isPending
+          }
         >
           Add Section
         </Button>
@@ -310,7 +363,14 @@ const CurriculumDashboard = () => {
       {sortedSections.map((section) => (
         <Accordion key={section._id} defaultExpanded sx={{ mb: 1 }}>
           <AccordionSummary expandIcon={<ExpandMore />}>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1, width: "100%" }}>
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                width: "100%",
+              }}
+            >
               <Folder color="primary" />
               {editingSection === section._id ? (
                 <>
@@ -327,10 +387,22 @@ const CurriculumDashboard = () => {
                     autoFocus
                     sx={{ flexGrow: 1 }}
                   />
-                  <IconButton size="small" onClick={(e) => { e.stopPropagation(); handleSaveSection(section._id); }}>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleSaveSection(section._id);
+                    }}
+                  >
                     <Check color="success" />
                   </IconButton>
-                  <IconButton size="small" onClick={(e) => { e.stopPropagation(); setEditingSection(null); }}>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setEditingSection(null);
+                    }}
+                  >
                     <Close />
                   </IconButton>
                 </>
@@ -345,12 +417,24 @@ const CurriculumDashboard = () => {
                     sx={{ mr: 1 }}
                   />
                   <Tooltip title="Edit">
-                    <IconButton size="small" onClick={(e) => { e.stopPropagation(); handleEditSection(section); }}>
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleEditSection(section);
+                      }}
+                    >
                       <Edit fontSize="small" />
                     </IconButton>
                   </Tooltip>
                   <Tooltip title="Delete">
-                    <IconButton size="small" onClick={(e) => { e.stopPropagation(); handleDeleteSection(section._id); }}>
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDeleteSection(section._id);
+                      }}
+                    >
                       <Delete fontSize="small" color="error" />
                     </IconButton>
                   </Tooltip>
@@ -374,11 +458,24 @@ const CurriculumDashboard = () => {
                     onSave={() => handleSaveLesson(lesson._id)}
                     onCancel={() => setEditingLesson(null)}
                     onDelete={() => handleDeleteLesson(lesson._id)}
-                    onAddCard={(front_text, back_text) => createCardMutation.mutate({ front_text, back_text, lesson_id: lesson._id })}
+                    onAddCard={(front_text, back_text) =>
+                      createCardMutation.mutate({
+                        front_text,
+                        back_text,
+                        lesson_id: lesson._id,
+                      })
+                    }
                     isAddingCard={createCardMutation.isPending}
-                    onUpdateCard={(id, front_text, back_text) => updateCardMutation.mutate({ id, front_text, back_text })}
+                    onUpdateCard={(id, front_text, back_text) =>
+                      updateCardMutation.mutate({ id, front_text, back_text })
+                    }
                     onDeleteCard={(id) => deleteCardMutation.mutate(id)}
-                    onUpdateOrder={(order) => updateLessonMutation.mutate({ id: lesson._id, order_index: order })}
+                    onUpdateOrder={(order) =>
+                      updateLessonMutation.mutate({
+                        id: lesson._id,
+                        order_index: order,
+                      })
+                    }
                     onEditContent={() => handleOpenEditLesson(lesson)}
                     getCategoryColor={getCategoryColor}
                   />
@@ -430,11 +527,24 @@ const CurriculumDashboard = () => {
                     onSave={() => handleSaveLesson(lesson._id)}
                     onCancel={() => setEditingLesson(null)}
                     onDelete={() => handleDeleteLesson(lesson._id)}
-                    onAddCard={(front_text, back_text) => createCardMutation.mutate({ front_text, back_text, lesson_id: lesson._id })}
+                    onAddCard={(front_text, back_text) =>
+                      createCardMutation.mutate({
+                        front_text,
+                        back_text,
+                        lesson_id: lesson._id,
+                      })
+                    }
                     isAddingCard={createCardMutation.isPending}
-                    onUpdateCard={(id, front_text, back_text) => updateCardMutation.mutate({ id, front_text, back_text })}
+                    onUpdateCard={(id, front_text, back_text) =>
+                      updateCardMutation.mutate({ id, front_text, back_text })
+                    }
                     onDeleteCard={(id) => deleteCardMutation.mutate(id)}
-                    onUpdateOrder={(order) => updateLessonMutation.mutate({ id: lesson._id, order_index: order })}
+                    onUpdateOrder={(order) =>
+                      updateLessonMutation.mutate({
+                        id: lesson._id,
+                        order_index: order,
+                      })
+                    }
                     onEditContent={() => handleOpenEditLesson(lesson)}
                     getCategoryColor={getCategoryColor}
                   />
@@ -455,9 +565,14 @@ const CurriculumDashboard = () => {
         sections={sections}
         defaultSectionId={defaultSectionForNewLesson}
         defaultOrderIndex={getNextOrderIndex(defaultSectionForNewLesson)}
-        onSave={(id, updates) => updateLessonContentMutation.mutate({ id, updates })}
+        onSave={(id, updates) =>
+          updateLessonContentMutation.mutate({ id, updates })
+        }
         onCreate={(newLesson) => createLessonMutation.mutate(newLesson)}
-        isSaving={updateLessonContentMutation.isPending || createLessonMutation.isPending}
+        isSaving={
+          updateLessonContentMutation.isPending ||
+          createLessonMutation.isPending
+        }
       />
     </Box>
   );
@@ -480,7 +595,9 @@ interface LessonItemProps {
   onDeleteCard: (id: string) => void;
   onUpdateOrder: (order: number) => void;
   onEditContent: () => void;
-  getCategoryColor: (category?: string) => "primary" | "secondary" | "grammar" | "default";
+  getCategoryColor: (
+    category?: string,
+  ) => "primary" | "secondary" | "grammar" | "default";
 }
 
 const LessonItem = ({
@@ -532,7 +649,11 @@ const LessonItem = ({
 
   const handleSaveCard = () => {
     if (editingCardId && editingCardFront.trim() && editingCardBack.trim()) {
-      onUpdateCard(editingCardId, editingCardFront.trim(), editingCardBack.trim());
+      onUpdateCard(
+        editingCardId,
+        editingCardFront.trim(),
+        editingCardBack.trim(),
+      );
       setEditingCardId(null);
     }
   };
@@ -579,7 +700,7 @@ const LessonItem = ({
           slotProps={{
             htmlInput: {
               min: 0,
-            }
+            },
           }}
           sx={{ width: 50, mr: 1, "& input": { p: 0.5 } }}
         />
@@ -608,7 +729,10 @@ const LessonItem = ({
           <>
             <ListItemText
               primary={lesson.title}
-              secondary={lesson.content?.slice(0, 60) + (lesson.content && lesson.content.length > 60 ? "..." : "")}
+              secondary={
+                lesson.content?.slice(0, 60) +
+                (lesson.content && lesson.content.length > 60 ? "..." : "")
+              }
             />
             {lesson.category && (
               <Chip
@@ -631,7 +755,8 @@ const LessonItem = ({
                 />
               </Tooltip>
             )}
-            {(lesson.category === "grammar" || lesson.category === "practice") && (
+            {(lesson.category === "grammar" ||
+              lesson.category === "practice") && (
               <Tooltip title="Edit Content">
                 <IconButton size="small" onClick={onEditContent}>
                   <Description fontSize="small" color="primary" />
@@ -662,11 +787,13 @@ const LessonItem = ({
       {/* Expandable cards grid - only for flashcard lessons */}
       {lesson.category === "flashcards" && expanded && (
         <Box sx={{ pl: 4, pt: 1 }}>
-          <Box sx={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
-            gap: 0.5,
-          }}>
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+              gap: 0.5,
+            }}
+          >
             {cards.map((card) => (
               <Box
                 key={card._id}
@@ -706,7 +833,13 @@ const LessonItem = ({
                       }}
                       fullWidth
                     />
-                    <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 0.5 }}>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        justifyContent: "flex-end",
+                        gap: 0.5,
+                      }}
+                    >
                       <IconButton size="small" onClick={handleSaveCard}>
                         <Check fontSize="small" color="success" />
                       </IconButton>
@@ -717,19 +850,39 @@ const LessonItem = ({
                   </>
                 ) : (
                   <>
-                    <Typography variant="body2" sx={{ fontWeight: 500, minWidth: 0 }} noWrap>
+                    <Typography
+                      variant="body2"
+                      sx={{ fontWeight: 500, minWidth: 0 }}
+                      noWrap
+                    >
                       {card.front_text}
                     </Typography>
-                    <Typography variant="body2" color="text.secondary" sx={{ mx: 0.5 }}>
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{ mx: 0.5 }}
+                    >
                       →
                     </Typography>
-                    <Typography variant="body2" color="text.secondary" sx={{ flex: 1, minWidth: 0 }} noWrap>
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{ flex: 1, minWidth: 0 }}
+                      noWrap
+                    >
                       {card.back_text}
                     </Typography>
-                    <IconButton size="small" onClick={() => handleStartEditCard(card)} sx={{ ml: "auto" }}>
+                    <IconButton
+                      size="small"
+                      onClick={() => handleStartEditCard(card)}
+                      sx={{ ml: "auto" }}
+                    >
                       <Edit fontSize="small" />
                     </IconButton>
-                    <IconButton size="small" onClick={() => handleDeleteCard(card._id)}>
+                    <IconButton
+                      size="small"
+                      onClick={() => handleDeleteCard(card._id)}
+                    >
                       <Delete fontSize="small" color="error" />
                     </IconButton>
                   </>
@@ -763,10 +916,19 @@ const LessonItem = ({
                 }}
                 sx={{ flex: 1 }}
               />
-              <IconButton size="small" onClick={handleAddCard} disabled={isAddingCard || !newCardFront.trim() || !newCardBack.trim()}>
+              <IconButton
+                size="small"
+                onClick={handleAddCard}
+                disabled={
+                  isAddingCard || !newCardFront.trim() || !newCardBack.trim()
+                }
+              >
                 <Check color="success" />
               </IconButton>
-              <IconButton size="small" onClick={() => setShowAddCardForm(false)}>
+              <IconButton
+                size="small"
+                onClick={() => setShowAddCardForm(false)}
+              >
                 <Close />
               </IconButton>
             </Box>

--- a/src/Routes/CurriculumDashboard.tsx
+++ b/src/Routes/CurriculumDashboard.tsx
@@ -1,0 +1,594 @@
+import { useState } from "react";
+import { useAuth } from "@/Contexts/AuthContext";
+import { useSnackbar } from "@/Contexts/SnackbarContext";
+import { useLessons, useSections } from "@/hooks/useLessons";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/utils/apiClient";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Paper,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  Add,
+  Delete,
+  Edit,
+  ExpandMore,
+  Folder,
+  Description,
+  Style,
+  Check,
+  Close,
+} from "@mui/icons-material";
+import { Section } from "@/types/sections";
+import { Lesson } from "@/types/lessons";
+import { Card } from "@/types/cards";
+
+const CurriculumDashboard = () => {
+  const { authData, authIsLoading } = useAuth();
+  const { showSnackbar } = useSnackbar();
+  const queryClient = useQueryClient();
+
+  // State for inline editing
+  const [editingSection, setEditingSection] = useState<string | null>(null);
+  const [editingLesson, setEditingLesson] = useState<string | null>(null);
+  const [editingSectionName, setEditingSectionName] = useState("");
+  const [editingLessonTitle, setEditingLessonTitle] = useState("");
+
+  // State for inline adding
+  const [addingSectionName, setAddingSectionName] = useState("");
+  const [addingLessonToSection, setAddingLessonToSection] = useState<
+    string | null
+  >(null);
+  const [addingLessonTitle, setAddingLessonTitle] = useState("");
+
+  // Fetch all data
+  const { data: sections = [], isLoading: isLoadingSections } =
+    useSections(authData);
+  const { data: lessons = [], isLoading: isLoadingLessons } =
+    useLessons(authData);
+  const { data: cards = [], isLoading: isLoadingCards } = useQuery({
+    queryKey: ["cards", authData?.token],
+    queryFn: async () => {
+      const response = await api.get<Card[]>("/api/cards/all");
+      return response.data;
+    },
+    enabled: !!authData,
+  });
+
+  // Mutations
+  const updateSectionMutation = useMutation({
+    mutationFn: async ({ id, name }: { id: string; name: string }) => {
+      await api.put(`/api/sections/update/${id}`, { name });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sections"] });
+      showSnackbar("Section updated", "success");
+      setEditingSection(null);
+    },
+    onError: () => showSnackbar("Failed to update section", "error"),
+  });
+
+  const deleteSectionMutation = useMutation({
+    mutationFn: async (id: string) => {
+      await api.delete(`/api/sections/delete/${id}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sections"] });
+      showSnackbar("Section deleted", "success");
+    },
+    onError: () => showSnackbar("Failed to delete section", "error"),
+  });
+
+  const createSectionMutation = useMutation({
+    mutationFn: async (name: string) => {
+      await api.post("/api/sections/create", { name, lesson_ids: [] });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sections"] });
+      showSnackbar("Section created", "success");
+      setAddingSectionName("");
+    },
+    onError: () => showSnackbar("Failed to create section", "error"),
+  });
+
+  const updateLessonMutation = useMutation({
+    mutationFn: async ({ id, title }: { id: string; title: string }) => {
+      await api.put(`/api/lessons/update/${id}`, { title });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["lessons"] });
+      showSnackbar("Lesson updated", "success");
+      setEditingLesson(null);
+    },
+    onError: () => showSnackbar("Failed to update lesson", "error"),
+  });
+
+  const deleteLessonMutation = useMutation({
+    mutationFn: async (id: string) => {
+      await api.delete(`/api/lessons/delete/${id}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["lessons"] });
+      showSnackbar("Lesson deleted", "success");
+    },
+    onError: () => showSnackbar("Failed to delete lesson", "error"),
+  });
+
+  const createLessonMutation = useMutation({
+    mutationFn: async ({
+      title,
+      section_id,
+    }: {
+      title: string;
+      section_id?: string;
+    }) => {
+      await api.post("/api/lessons/create", { title, section_id });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["lessons"] });
+      queryClient.invalidateQueries({ queryKey: ["sections"] });
+      showSnackbar("Lesson created", "success");
+      setAddingLessonToSection(null);
+      setAddingLessonTitle("");
+    },
+    onError: () => showSnackbar("Failed to create lesson", "error"),
+  });
+
+  // Helper functions
+  const getLessonsForSection = (sectionId: string): Lesson[] => {
+    return lessons.filter((l) => l.section_id === sectionId);
+  };
+
+  const getUngroupedLessons = (): Lesson[] => {
+    return lessons.filter((l) => !l.section_id);
+  };
+
+  const getCardsForLesson = (lessonId: string): Card[] => {
+    return cards.filter((c) => c.lesson_ids.includes(lessonId));
+  };
+
+  const getCategoryColor = (category?: string) => {
+    switch (category?.toLowerCase()) {
+      case "grammar":
+        return "primary";
+      case "flashcards":
+        return "secondary";
+      case "practice":
+        return "success";
+      default:
+        return "default";
+    }
+  };
+
+  // Event handlers
+  const handleEditSection = (section: Section) => {
+    setEditingSection(section._id);
+    setEditingSectionName(section.name);
+  };
+
+  const handleSaveSection = (id: string) => {
+    if (editingSectionName.trim()) {
+      updateSectionMutation.mutate({ id, name: editingSectionName });
+    }
+  };
+
+  const handleDeleteSection = (id: string) => {
+    if (window.confirm("Delete this section? Lessons will become ungrouped.")) {
+      deleteSectionMutation.mutate(id);
+    }
+  };
+
+  const handleAddSection = () => {
+    if (addingSectionName.trim()) {
+      createSectionMutation.mutate(addingSectionName);
+    }
+  };
+
+  const handleEditLesson = (lesson: Lesson) => {
+    setEditingLesson(lesson._id);
+    setEditingLessonTitle(lesson.title);
+  };
+
+  const handleSaveLesson = (id: string) => {
+    if (editingLessonTitle.trim()) {
+      updateLessonMutation.mutate({ id, title: editingLessonTitle });
+    }
+  };
+
+  const handleDeleteLesson = (id: string) => {
+    if (window.confirm("Delete this lesson?")) {
+      deleteLessonMutation.mutate(id);
+    }
+  };
+
+  const handleAddLesson = (sectionId?: string) => {
+    if (addingLessonTitle.trim()) {
+      createLessonMutation.mutate({
+        title: addingLessonTitle,
+        section_id: sectionId,
+      });
+    }
+  };
+
+  // Loading state
+  if (
+    isLoadingSections ||
+    isLoadingLessons ||
+    isLoadingCards ||
+    authIsLoading
+  ) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", mt: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  // Sort sections by order_index
+  const sortedSections = [...sections].sort(
+    (a, b) => (a.order_index ?? 0) - (b.order_index ?? 0),
+  );
+
+  return (
+    <Box sx={{ maxWidth: 1200, mx: "auto", p: 3 }}>
+      <Typography variant="h4" gutterBottom sx={{ mb: 3 }}>
+        Curriculum Dashboard
+      </Typography>
+
+      {/* Add Section Form */}
+      <Paper
+        sx={{ p: 2, mb: 3, display: "flex", gap: 2, alignItems: "center" }}
+      >
+        <TextField
+          size="small"
+          label="New Section Name"
+          value={addingSectionName}
+          onChange={(e) => setAddingSectionName(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleAddSection()}
+          sx={{ flexGrow: 1, maxWidth: 300 }}
+        />
+        <Button
+          variant="contained"
+          startIcon={<Add />}
+          onClick={handleAddSection}
+          disabled={
+            !addingSectionName.trim() || createSectionMutation.isPending
+          }
+        >
+          Add Section
+        </Button>
+      </Paper>
+
+      {/* Sections */}
+      {sortedSections.map((section) => (
+        <Accordion key={section._id} defaultExpanded sx={{ mb: 1 }}>
+          <AccordionSummary expandIcon={<ExpandMore />}>
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                width: "100%",
+              }}
+            >
+              <Folder color="primary" />
+              {editingSection === section._id ? (
+                <>
+                  <TextField
+                    size="small"
+                    value={editingSectionName}
+                    onChange={(e) => setEditingSectionName(e.target.value)}
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => {
+                      e.stopPropagation();
+                      if (e.key === "Enter") handleSaveSection(section._id);
+                      if (e.key === "Escape") setEditingSection(null);
+                    }}
+                    autoFocus
+                    sx={{ flexGrow: 1 }}
+                  />
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleSaveSection(section._id);
+                    }}
+                  >
+                    <Check color="success" />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setEditingSection(null);
+                    }}
+                  >
+                    <Close />
+                  </IconButton>
+                </>
+              ) : (
+                <>
+                  <Typography variant="h6" sx={{ flexGrow: 1 }}>
+                    {section.name}
+                  </Typography>
+                  <Chip
+                    label={`${getLessonsForSection(section._id).length} lessons`}
+                    size="small"
+                    sx={{ mr: 1 }}
+                  />
+                  <Tooltip title="Edit">
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleEditSection(section);
+                      }}
+                    >
+                      <Edit fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Delete">
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDeleteSection(section._id);
+                      }}
+                    >
+                      <Delete fontSize="small" color="error" />
+                    </IconButton>
+                  </Tooltip>
+                </>
+              )}
+            </Box>
+          </AccordionSummary>
+          <AccordionDetails>
+            <List dense>
+              {getLessonsForSection(section._id)
+                .sort((a, b) => (a.order_index ?? 0) - (b.order_index ?? 0))
+                .map((lesson) => (
+                  <LessonItem
+                    key={lesson._id}
+                    lesson={lesson}
+                    cards={getCardsForLesson(lesson._id)}
+                    isEditing={editingLesson === lesson._id}
+                    editingTitle={editingLessonTitle}
+                    onEditingTitleChange={setEditingLessonTitle}
+                    onEdit={() => handleEditLesson(lesson)}
+                    onSave={() => handleSaveLesson(lesson._id)}
+                    onCancel={() => setEditingLesson(null)}
+                    onDelete={() => handleDeleteLesson(lesson._id)}
+                    getCategoryColor={getCategoryColor}
+                  />
+                ))}
+            </List>
+
+            {/* Add lesson to section */}
+            {addingLessonToSection === section._id ? (
+              <Box sx={{ display: "flex", gap: 1, mt: 1, pl: 2 }}>
+                <TextField
+                  size="small"
+                  label="Lesson Title"
+                  value={addingLessonTitle}
+                  onChange={(e) => setAddingLessonTitle(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleAddLesson(section._id);
+                    if (e.key === "Escape") setAddingLessonToSection(null);
+                  }}
+                  autoFocus
+                  sx={{ flexGrow: 1 }}
+                />
+                <IconButton onClick={() => handleAddLesson(section._id)}>
+                  <Check color="success" />
+                </IconButton>
+                <IconButton onClick={() => setAddingLessonToSection(null)}>
+                  <Close />
+                </IconButton>
+              </Box>
+            ) : (
+              <Button
+                size="small"
+                startIcon={<Add />}
+                onClick={() => setAddingLessonToSection(section._id)}
+                sx={{ ml: 2 }}
+              >
+                Add Lesson
+              </Button>
+            )}
+          </AccordionDetails>
+        </Accordion>
+      ))}
+
+      {/* Ungrouped Lessons */}
+      {getUngroupedLessons().length > 0 && (
+        <Accordion defaultExpanded sx={{ mb: 1 }}>
+          <AccordionSummary expandIcon={<ExpandMore />}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <Folder color="disabled" />
+              <Typography variant="h6" color="text.secondary">
+                Ungrouped Lessons
+              </Typography>
+              <Chip
+                label={`${getUngroupedLessons().length} lessons`}
+                size="small"
+                sx={{ ml: 1 }}
+              />
+            </Box>
+          </AccordionSummary>
+          <AccordionDetails>
+            <List dense>
+              {getUngroupedLessons()
+                .sort((a, b) => (a.order_index ?? 0) - (b.order_index ?? 0))
+                .map((lesson) => (
+                  <LessonItem
+                    key={lesson._id}
+                    lesson={lesson}
+                    cards={getCardsForLesson(lesson._id)}
+                    isEditing={editingLesson === lesson._id}
+                    editingTitle={editingLessonTitle}
+                    onEditingTitleChange={setEditingLessonTitle}
+                    onEdit={() => handleEditLesson(lesson)}
+                    onSave={() => handleSaveLesson(lesson._id)}
+                    onCancel={() => setEditingLesson(null)}
+                    onDelete={() => handleDeleteLesson(lesson._id)}
+                    getCategoryColor={getCategoryColor}
+                  />
+                ))}
+            </List>
+          </AccordionDetails>
+        </Accordion>
+      )}
+    </Box>
+  );
+};
+
+// Lesson item sub-component
+interface LessonItemProps {
+  lesson: Lesson;
+  cards: Card[];
+  isEditing: boolean;
+  editingTitle: string;
+  onEditingTitleChange: (title: string) => void;
+  onEdit: () => void;
+  onSave: () => void;
+  onCancel: () => void;
+  onDelete: () => void;
+  getCategoryColor: (
+    category?: string,
+  ) => "primary" | "secondary" | "success" | "default";
+}
+
+const LessonItem = ({
+  lesson,
+  cards,
+  isEditing,
+  editingTitle,
+  onEditingTitleChange,
+  onEdit,
+  onSave,
+  onCancel,
+  onDelete,
+  getCategoryColor,
+}: LessonItemProps) => {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <Box sx={{ mb: 1 }}>
+      <ListItem
+        sx={{
+          bgcolor: "background.paper",
+          borderRadius: 1,
+          border: "1px solid",
+          borderColor: "divider",
+        }}
+      >
+        <Description sx={{ mr: 1.5, color: "text.secondary" }} />
+        {isEditing ? (
+          <>
+            <TextField
+              size="small"
+              value={editingTitle}
+              onChange={(e) => onEditingTitleChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") onSave();
+                if (e.key === "Escape") onCancel();
+              }}
+              autoFocus
+              sx={{ flexGrow: 1 }}
+            />
+            <IconButton size="small" onClick={onSave}>
+              <Check color="success" />
+            </IconButton>
+            <IconButton size="small" onClick={onCancel}>
+              <Close />
+            </IconButton>
+          </>
+        ) : (
+          <>
+            <ListItemText
+              primary={lesson.title}
+              secondary={
+                lesson.content?.slice(0, 60) +
+                (lesson.content && lesson.content.length > 60 ? "..." : "")
+              }
+            />
+            {lesson.category && (
+              <Chip
+                label={lesson.category}
+                size="small"
+                color={getCategoryColor(lesson.category)}
+                sx={{ mr: 1 }}
+              />
+            )}
+            {cards.length > 0 && (
+              <Tooltip title="View cards">
+                <Chip
+                  icon={<Style fontSize="small" />}
+                  label={cards.length}
+                  size="small"
+                  variant="outlined"
+                  onClick={() => setExpanded(!expanded)}
+                  sx={{ mr: 1, cursor: "pointer" }}
+                />
+              </Tooltip>
+            )}
+            <Tooltip title="Edit">
+              <IconButton size="small" onClick={onEdit}>
+                <Edit fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Delete">
+              <IconButton size="small" onClick={onDelete}>
+                <Delete fontSize="small" color="error" />
+              </IconButton>
+            </Tooltip>
+          </>
+        )}
+      </ListItem>
+
+      {/* Expandable cards list */}
+      {expanded && cards.length > 0 && (
+        <Box sx={{ pl: 4, pt: 1 }}>
+          {cards.map((card) => (
+            <Box
+              key={card._id}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                py: 0.5,
+                px: 1,
+                bgcolor: "action.hover",
+                borderRadius: 0.5,
+                mb: 0.5,
+              }}
+            >
+              <Style fontSize="small" color="disabled" />
+              <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                {card.front_text}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                → {card.back_text}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default CurriculumDashboard;


### PR DESCRIPTION
## Brief Description

<!-- Describe the purpose of this pull request -->

In this pull request, I added a single unified dashboard for editing lessons/cards/sections to make curriculum development easier

## Changes

<!-- Describe the changes made in this pull request -->

- There's a new "/curriculum" admin route
- There's a new `CurriculumDashboard.tsx` component
- There's a new `LessonEditModal.tsx` component that shows when creating new lessons or editing grammar and practice lessons